### PR TITLE
feat: add Ubuntu desktop integration for popup GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ In case you want to both build and set it in your path then execute `task instal
 If you want to test the popup GUI on Linux, install the desktop build dependencies first with `task deps:gui:ubuntu` or `task deps:gui:fedora`, then run it with `task run:gui`.
 These tasks currently use distro-specific package names for the Fyne desktop stack.
 
-If you want user-scoped desktop integration on Fedora, run `task integration:fedora`.
-This installs `agent-gui` into `~/.local/bin/agent-gui`, writes a desktop entry, configures the GNOME shortcut automatically, and lets KDE Plasma discover `Terminal Agent Popup` in Shortcuts so you can bind `Ctrl+Shift+Space` there.
+If you want user-scoped desktop integration, run one of these tasks:
+
+- Ubuntu: `task integration:ubuntu`
+- Fedora: `task integration:fedora`
+
+Both install `agent-gui` into `~/.local/bin/agent-gui`, write a desktop entry, configure the GNOME shortcut automatically, and let KDE Plasma discover `Terminal Agent Popup` in Shortcuts so you can bind `Ctrl+Shift+Space` there.
 
 For majority of cases, do check out the `Taskfile.dist.yaml` as it has most relevant tasks / receipies.
 

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -84,6 +84,18 @@ tasks:
       - bash scripts/integ_fedora.sh --uninstall
     silent: false
 
+  integration:ubuntu:
+    desc: Install Ubuntu desktop integration for the popup GUI
+    cmds:
+      - bash scripts/integ_ubuntu.sh
+    silent: false
+
+  integration:ubuntu:uninstall:
+    desc: Remove Ubuntu desktop integration for the popup GUI
+    cmds:
+      - bash scripts/integ_ubuntu.sh --uninstall
+    silent: false
+
   run:ask:
     vars:
       ARGS: "{{.CLI_ARGS}}"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,14 +36,20 @@ If you prefer to build from source:
 
 This will place the `agent` binary in `~/.local/bin/agent`.
 
-If you want the popup GUI on Fedora, run:
+If you want the popup GUI with user-scoped desktop integration on Ubuntu, run:
+
+```sh
+task integration:ubuntu
+```
+
+If you are on Fedora, use:
 
 ```sh
 task integration:fedora
 ```
 
-This installs `agent-gui` to `~/.local/bin/agent-gui` and sets up the desktop launcher for the current user.
-The Fedora integration configures `Ctrl+Shift+Space` automatically on GNOME. On KDE Plasma, run the integration first, then bind a shortcut to the discovered `Terminal Agent Popup` entry in System Settings -> Keyboard -> Shortcuts.
+Both integrations install `agent-gui` to `~/.local/bin/agent-gui` and set up the desktop launcher for the current user.
+On GNOME, `Ctrl+Shift+Space` is configured automatically. On KDE Plasma, run the integration first, then bind a shortcut to the discovered `Terminal Agent Popup` entry in System Settings -> Keyboard -> Shortcuts.
 
 For local GUI development, especially if a launcher-managed popup instance is already running, start an isolated test instance with:
 

--- a/docs/integration/ubuntu.md
+++ b/docs/integration/ubuntu.md
@@ -1,0 +1,118 @@
+# Ubuntu Integration
+
+This guide covers the supported Ubuntu desktop integration path for the Terminal Agent popup GUI.
+
+## What this does
+
+Running `task integration:ubuntu` installs the popup GUI for the current user and configures the desktop launcher path around `~/.local/bin/agent-gui`.
+
+The integration script performs these steps automatically:
+
+- checks that the host is Ubuntu (`ID=ubuntu`)
+- installs missing Fyne desktop build dependencies with `apt-get`
+- builds `agent-gui`
+- installs `agent-gui` to `~/.local/bin/agent-gui`
+- installs a desktop entry in `~/.local/share/applications/terminal-agent-gui.desktop`
+- installs the popup icon in the user icon directory
+- refreshes the desktop application database when available
+- validates the desktop entry
+- detects GNOME or KDE Plasma and prepares the supported shortcut path for that desktop
+- supports `--uninstall` to remove the installed user-scoped integration files and shortcut configuration
+
+## Run the integration
+
+```sh
+task integration:ubuntu
+```
+
+To uninstall the Ubuntu integration:
+
+```sh
+bash scripts/integ_ubuntu.sh --uninstall
+```
+
+The script is user-scoped. It installs the launcher and binary in your home directory.
+
+## Resulting behavior
+
+After setup:
+
+- `agent-gui` starts the popup app normally
+- `agent-gui --show` reopens the hidden popup in the existing instance
+- `agent-gui --new` starts a separate isolated popup instance for local testing
+- pressing `Escape` hides the popup
+- the desktop shortcut is configured to run `agent-gui --show`
+- the popup `Settings` button updates the shared default provider/model used by GUI asks
+
+## Ubuntu GNOME
+
+On GNOME, the integration script configures a custom shortcut for `~/.local/bin/agent-gui --show` using `gsettings`.
+
+Default shortcut:
+
+```text
+Ctrl+Shift+Space
+```
+
+If that binding conflicts with your current setup, change it in the GNOME keyboard shortcut settings after the script finishes.
+
+## Ubuntu KDE Plasma
+
+On KDE Plasma, the current verified working path is desktop-entry discovery through Plasma Shortcuts.
+
+After running `task integration:ubuntu`, Plasma discovers the installed `Terminal Agent Popup` launcher in the Shortcuts settings. You can then assign a shortcut to that discovered application entry, and Plasma will launch the popup even when `agent-gui` is not already running.
+
+Suggested setup steps:
+
+1. Run `task integration:ubuntu`.
+2. Open `System Settings` -> `Keyboard` -> `Shortcuts`.
+3. Find `Terminal Agent Popup` in the applications list.
+4. Select it and add a shortcut such as `Ctrl+Shift+Space`.
+5. Save the shortcut.
+
+Default shortcut:
+
+```text
+Ctrl+Shift+Space
+```
+
+Fallback if Plasma does not expose the application entry correctly:
+
+1. Open `System Settings` -> `Keyboard` -> `Shortcuts`.
+2. Create a custom command shortcut.
+3. Set the command to `~/.local/bin/agent-gui --show`.
+4. Bind `Ctrl+Shift+Space` or another available shortcut.
+
+## Files installed
+
+```text
+~/.local/bin/agent-gui
+~/.local/share/applications/terminal-agent-gui.desktop
+~/.local/share/icons/hicolor/256x256/apps/terminal-agent.png
+```
+
+These files are removed again by `scripts/integ_ubuntu.sh --uninstall`.
+
+## Verification
+
+The script validates the desktop entry and checks that the installed binary is runnable.
+
+You can also verify manually:
+
+```sh
+~/.local/bin/agent-gui
+~/.local/bin/agent-gui --show
+~/.local/bin/agent-gui --new
+desktop-file-validate ~/.local/share/applications/terminal-agent-gui.desktop
+```
+
+## Troubleshooting
+
+If shortcut automation does not complete:
+
+- confirm whether you are running GNOME or KDE Plasma
+- verify that `~/.local/bin` is present and readable
+- run `~/.local/bin/agent-gui --show` directly to confirm the popup path works
+- on KDE Plasma, first try the discovered `Terminal Agent Popup` application entry in Shortcuts
+- if that does not work, fall back to a custom command shortcut for `~/.local/bin/agent-gui --show`
+- re-run `task integration:ubuntu` after fixing any missing desktop tooling

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,9 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Integration:
+      - Fedora: integration/fedora.md
+      - Ubuntu: integration/ubuntu.md
   - Commands:
       - Overview: commands.md
       - Ask Command: commands/ask.md

--- a/scripts/integ_ubuntu.sh
+++ b/scripts/integ_ubuntu.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCAL_BIN_DIR="${HOME}/.local/bin"
+LOCAL_APP_DIR="${HOME}/.local/share/applications"
+LOCAL_ICON_DIR="${HOME}/.local/share/icons/hicolor/256x256/apps"
+GUI_BIN_PATH="${LOCAL_BIN_DIR}/agent-gui"
+DESKTOP_FILE_PATH="${LOCAL_APP_DIR}/terminal-agent-gui.desktop"
+ICON_PATH="${LOCAL_ICON_DIR}/terminal-agent.png"
+DESKTOP_TEMPLATE_PATH="${REPO_ROOT}/packaging/linux/terminal-agent-gui.desktop"
+ICON_SOURCE_PATH="${REPO_ROOT}/assets/icon.png"
+SHORTCUT_LABEL="Ctrl+Shift+Space"
+
+log() {
+  printf '[terminal-agent] %s\n' "$1"
+}
+
+fail() {
+  printf '[terminal-agent] ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+detect_desktop() {
+  local current desktop session
+  current="${XDG_CURRENT_DESKTOP:-}"
+  desktop="${DESKTOP_SESSION:-}"
+  session="${XDG_SESSION_DESKTOP:-}"
+  case "${current}:${desktop}:${session}" in
+    *GNOME*|*gnome*)
+      printf 'gnome\n'
+      ;;
+    *KDE*|*Plasma*|*plasma*)
+      printf 'kde\n'
+      ;;
+    *)
+      printf 'unknown\n'
+      ;;
+  esac
+}
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/integ_ubuntu.sh [--uninstall]
+
+Installs or removes the Ubuntu desktop integration for Terminal Agent popup GUI.
+EOF
+}
+
+ensure_dirs() {
+  mkdir -p "${LOCAL_BIN_DIR}" "${LOCAL_APP_DIR}" "${LOCAL_ICON_DIR}"
+}
+
+ensure_ubuntu() {
+  need_cmd apt-get
+  if [[ -r /etc/os-release ]]; then
+    if ! grep -Eiq '^ID="?ubuntu"?$' /etc/os-release; then
+      fail "This integration script is intended for Ubuntu."
+    fi
+  fi
+}
+
+ensure_build_deps() {
+  local packages=()
+  local pkg
+  for pkg in libgl1-mesa-dev xorg-dev libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxxf86vm-dev desktop-file-utils; do
+    if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+      packages+=("$pkg")
+    fi
+  done
+
+  if ((${#packages[@]} > 0)); then
+    log "Installing missing GUI build dependencies via apt-get"
+    sudo apt-get update
+    sudo apt-get install -y "${packages[@]}"
+  else
+    log "Required GUI build dependencies already installed"
+  fi
+}
+
+build_gui_binary() {
+  need_cmd go
+  log "Building agent-gui"
+  mkdir -p "${REPO_ROOT}/bin"
+  go build -o "${REPO_ROOT}/bin/agent-gui" "${REPO_ROOT}/cmd/agent-gui/main.go"
+}
+
+install_gui_binary() {
+  [[ -x "${REPO_ROOT}/bin/agent-gui" ]] || fail "Expected built binary at ${REPO_ROOT}/bin/agent-gui"
+  install -m 0755 "${REPO_ROOT}/bin/agent-gui" "${GUI_BIN_PATH}"
+  log "Installed agent-gui to ${GUI_BIN_PATH}"
+}
+
+install_icon() {
+  [[ -f "${ICON_SOURCE_PATH}" ]] || fail "Missing icon asset at ${ICON_SOURCE_PATH}"
+  install -m 0644 "${ICON_SOURCE_PATH}" "${ICON_PATH}"
+  log "Installed icon to ${ICON_PATH}"
+}
+
+install_desktop_entry() {
+  [[ -f "${DESKTOP_TEMPLATE_PATH}" ]] || fail "Missing desktop entry template at ${DESKTOP_TEMPLATE_PATH}"
+  sed \
+    -e "s|__AGENT_GUI_PATH__|${GUI_BIN_PATH}|g" \
+    -e "s|__ICON_PATH__|${ICON_PATH}|g" \
+    "${DESKTOP_TEMPLATE_PATH}" > "${DESKTOP_FILE_PATH}"
+  chmod 0644 "${DESKTOP_FILE_PATH}"
+  log "Installed desktop entry to ${DESKTOP_FILE_PATH}"
+}
+
+refresh_desktop_database() {
+  if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "${LOCAL_APP_DIR}" >/dev/null 2>&1 || true
+    log "Refreshed desktop application database"
+  fi
+  if command -v kbuildsycoca6 >/dev/null 2>&1; then
+    kbuildsycoca6 --noincremental >/dev/null 2>&1 || true
+    log "Rebuilt KDE service cache"
+  fi
+}
+
+reload_kde_shortcuts() {
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl --user restart plasma-kglobalaccel.service >/dev/null 2>&1 || true
+  fi
+  if command -v dbus-send >/dev/null 2>&1; then
+    dbus-send --session --dest=org.kde.kglobalaccel --print-reply /kglobalaccel org.kde.KGlobalAccel.reloadConfig >/dev/null 2>&1 || true
+  fi
+  log "Requested KDE global shortcut reload"
+}
+
+configure_gnome_shortcut() {
+  need_cmd gsettings
+
+  local shortcut_path="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/terminal-agent-gui/"
+  local current_list raw_list new_list escaped_command
+  escaped_command="${GUI_BIN_PATH} --show"
+  current_list="$(gsettings get org.gnome.settings-daemon.plugins.media-keys custom-keybindings)"
+
+  if [[ "${current_list}" != *"${shortcut_path}"* ]]; then
+    raw_list="${current_list#[}"
+    raw_list="${raw_list%]}"
+    if [[ -n "${raw_list// }" ]]; then
+      new_list="[${raw_list}, '${shortcut_path}']"
+    else
+      new_list="['${shortcut_path}']"
+    fi
+    gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "${new_list}"
+  fi
+
+  gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${shortcut_path} name 'Terminal Agent Popup'
+  gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${shortcut_path} command "${escaped_command}"
+  gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${shortcut_path} binding '<Primary><Shift>space'
+
+  log "Configured GNOME shortcut ${SHORTCUT_LABEL} for agent-gui --show"
+}
+
+configure_kde_shortcut() {
+  if ! command -v kwriteconfig6 >/dev/null 2>&1; then
+    log "KDE shortcut automation is not enabled; use Plasma Shortcuts to bind the discovered 'Terminal Agent Popup' entry"
+    return 0
+  fi
+
+  log "KDE detected: open Plasma Shortcuts and bind the discovered 'Terminal Agent Popup' entry"
+  log "If the application entry is missing, fall back to a custom command shortcut: ${GUI_BIN_PATH} --show"
+}
+
+remove_gnome_shortcut() {
+  if ! command -v gsettings >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local shortcut_path="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/terminal-agent-gui/"
+  local current_list raw_list new_list
+  current_list="$(gsettings get org.gnome.settings-daemon.plugins.media-keys custom-keybindings 2>/dev/null || printf '[]')"
+  if [[ "${current_list}" != *"${shortcut_path}"* ]]; then
+    return 0
+  fi
+
+  raw_list="${current_list#[}"
+  raw_list="${raw_list%]}"
+  new_list="$(printf '%s' "${raw_list}" | sed "s#'${shortcut_path}', \|, '${shortcut_path}'\|'${shortcut_path}'##g")"
+  if [[ -n "${new_list// }" ]]; then
+    gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "[${new_list}]"
+  else
+    gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "[]"
+  fi
+  log "Removed GNOME shortcut configuration for Terminal Agent Popup"
+}
+
+remove_kde_shortcut() {
+  if ! command -v kwriteconfig6 >/dev/null 2>&1; then
+    return 0
+  fi
+
+  log "No KDE shortcut automation to remove"
+}
+
+uninstall_integration() {
+  local desktop
+  desktop="$(detect_desktop)"
+  case "${desktop}" in
+    gnome)
+      remove_gnome_shortcut
+      ;;
+    kde)
+      remove_kde_shortcut
+      ;;
+  esac
+
+  rm -f "${DESKTOP_FILE_PATH}" "${ICON_PATH}" "${GUI_BIN_PATH}"
+  refresh_desktop_database
+  log "Removed Ubuntu desktop integration files"
+}
+
+verify_installation() {
+  [[ -x "${GUI_BIN_PATH}" ]] || fail "Installed GUI binary is missing or not executable"
+  [[ -f "${DESKTOP_FILE_PATH}" ]] || fail "Desktop entry was not installed"
+  grep -q "Exec=${GUI_BIN_PATH} --show" "${DESKTOP_FILE_PATH}" || fail "Desktop entry Exec line is incorrect"
+  grep -q "Icon=${ICON_PATH}" "${DESKTOP_FILE_PATH}" || fail "Desktop entry Icon line is incorrect"
+  desktop-file-validate "${DESKTOP_FILE_PATH}" >/dev/null 2>&1 || fail "desktop-file-validate reported an invalid desktop entry"
+  "${GUI_BIN_PATH}" --help >/dev/null 2>&1 || fail "Installed GUI binary is not runnable"
+  log "Verified GUI binary and desktop entry"
+}
+
+verify_kde_shortcut() {
+  log "KDE verification: check that Plasma Shortcuts shows 'Terminal Agent Popup', then bind ${SHORTCUT_LABEL} there"
+}
+
+print_summary() {
+  local desktop="$1"
+  log "Ubuntu desktop integration complete"
+  log "Desktop detected: ${desktop}"
+  log "Launcher installed: ${DESKTOP_FILE_PATH}"
+  log "Binary installed: ${GUI_BIN_PATH}"
+  log "Use 'agent-gui' for a normal launch or '${GUI_BIN_PATH} --show' to reopen the popup"
+  case "${desktop}" in
+    gnome)
+      log "Shortcut configured: ${SHORTCUT_LABEL}"
+      ;;
+    kde)
+      log "Next step on KDE: bind ${SHORTCUT_LABEL} to the discovered 'Terminal Agent Popup' shortcut entry"
+      ;;
+    *)
+      log "Suggested shortcut: ${SHORTCUT_LABEL}"
+      ;;
+  esac
+}
+
+main() {
+  local uninstall="false"
+  case "${1:-}" in
+    --uninstall)
+      uninstall="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    "")
+      ;;
+    *)
+      usage
+      fail "Unknown argument: ${1}"
+      ;;
+  esac
+
+  [[ $# -eq 0 ]] || fail "Unexpected extra arguments"
+
+  ensure_ubuntu
+  if [[ "${uninstall}" == "true" ]]; then
+    uninstall_integration
+    return
+  fi
+
+  ensure_dirs
+  ensure_build_deps
+  build_gui_binary
+  install_gui_binary
+  install_icon
+  install_desktop_entry
+  refresh_desktop_database
+
+  need_cmd desktop-file-validate
+  local desktop
+  desktop="$(detect_desktop)"
+  case "${desktop}" in
+    gnome)
+      configure_gnome_shortcut
+      ;;
+    kde)
+      configure_kde_shortcut
+      verify_kde_shortcut
+      ;;
+    unknown)
+      log "Skipping shortcut automation because the desktop environment could not be identified"
+      ;;
+  esac
+
+  verify_installation
+  print_summary "${desktop}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a strict Ubuntu-only desktop integration flow (`task integration:ubuntu`) for the popup GUI, mirroring the Fedora workflow for install and uninstall
- install required Ubuntu GUI/build dependencies, build and install `agent-gui`, install desktop entry/icon, validate desktop file, and configure `Ctrl+Shift+Space` on GNOME to run `agent-gui --show`
- document the new Ubuntu integration path in a dedicated guide and update getting-started/readme docs and docs navigation

## Verification
- `bash -n scripts/integ_ubuntu.sh`
- `task -t Taskfile.dist.yaml --list | rg \"integration:(fedora|ubuntu)\"`