### PR TITLE
feat: add OpenAI Codex auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,19 @@ $ agent config set anthropic.claude-3-haiku-20240307-v1:0
 
 ### OpenAI
 
-To use `agent` with OpenAI, you need to set the `OPENAI_API_KEY` environment variable with your individual key, and then set the provider to `openai`.
+OpenAI supports two authentication methods:
+
+**Option 1: API key** (traditional)
+Set the key as an environment variable:
+```sh
+export OPENAI_API_KEY=your_api_key_here
+```
+
+**Option 2: Stored credentials** (recommended)
+Use the `agent auth` command to store your API key or authenticate with your ChatGPT account:
+```sh
+agent auth login openai --api-key
+```
 
 Setting `openai` provider with `gpt-4o-mini` model can be done with `task run:set:openai` or directly
 
@@ -181,6 +193,8 @@ Setting `openai` provider with `gpt-4o-mini` model can be done with `task run:se
 $ agent config set provider openai
 $ agent config set model gpt-4o-mini
 ```
+
+See `agent auth --help` for more authentication options.
 
 ### Ollama
 

--- a/README.md
+++ b/README.md
@@ -184,14 +184,24 @@ export OPENAI_API_KEY=your_api_key_here
 **Option 2: Stored credentials** (recommended)
 Use the `agent auth` command to store your API key or authenticate with your ChatGPT account:
 ```sh
-agent auth login openai --api-key
+agent auth login openai               # browser OAuth login
+agent auth login openai --device      # terminal-friendly device login
+agent auth login openai --api-key     # store an API key
 ```
+
+If the browser callback does not return automatically, the browser login flow also accepts a pasted authorization code or full redirect URL as a fallback.
 
 Setting `openai` provider with `gpt-4o-mini` model can be done with `task run:set:openai` or directly
 
 ```sh
 $ agent config set provider openai
 $ agent config set model gpt-4o-mini
+```
+
+Check the current auth state with:
+
+```sh
+agent auth status openai
 ```
 
 See `agent auth --help` for more authentication options.

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -118,6 +118,7 @@ func mainRun() exitCode {
 	cmd.AddCommand(commands.NewToolCommand(c))
 	cmd.AddCommand(commands.NewTaskCommand(c))
 	cmd.AddCommand(commands.NewMemoryCommand())
+	cmd.AddCommand(commands.NewAuthCommand())
 	cmd.AddCommand(commands.NewPluginCommand())
 
 	ctx := context.Background()

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -16,8 +16,20 @@ Authenticate with a provider:
 
 ```sh
 agent auth login openai
+agent auth login openai --device
 agent auth login openai --api-key
 ```
+
+- `agent auth login openai` starts the browser OAuth flow.
+- `agent auth login openai --device` starts the terminal-friendly device-code flow.
+- `agent auth login openai --api-key` stores an API key without using OAuth.
+
+Browser login supports a pasted-code fallback. If the localhost callback does not complete automatically, paste either:
+
+- the full redirect URL
+- the raw authorization code
+- `code#state`
+- a query string containing `code=` and optional `state=`
 
 When `--api-key` is used, the command reads the key from the `--key` flag, the `OPENAI_API_KEY` environment variable, an interactive terminal prompt, or stdin (in that order).
 
@@ -52,6 +64,8 @@ Source: stored
 
 If `OPENAI_API_KEY` is set in the environment, `Source` will show `environment` instead.
 
+For OAuth logins, status also shows `Account ID`, `Plan type`, `Expires`, and `Expired` when that metadata is available.
+
 ### logout
 
 Remove stored credentials for a provider:
@@ -71,6 +85,8 @@ Credentials are stored in:
 ```
 
 The file is created with `0600` permissions and uses atomic writes to avoid data corruption.
+
+For stored OAuth logins, Terminal Agent refreshes access tokens automatically while a valid refresh token is still present.
 
 ## Auth Resolution
 

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -1,0 +1,84 @@
+# Auth Command
+
+The `auth` command manages provider credentials. It stores API keys and OAuth tokens separately from the main config file, in `~/.config/terminal-agent/auth.json`.
+
+## Usage
+
+```sh
+agent auth <subcommand> [args]
+```
+
+## Subcommands
+
+### login
+
+Authenticate with a provider:
+
+```sh
+agent auth login openai
+agent auth login openai --api-key
+```
+
+When `--api-key` is used, the command reads the key from the `--key` flag, the `OPENAI_API_KEY` environment variable, an interactive terminal prompt, or stdin (in that order).
+
+```sh
+# Store an API key from the environment
+agent auth login openai --api-key
+
+# Store a specific key
+agent auth login openai --api-key --key sk-proj-...
+
+# Read the key from a pipe
+echo "$OPENAI_API_KEY" | agent auth login openai --api-key
+```
+
+### status
+
+Show auth status for a provider:
+
+```sh
+agent auth status openai
+```
+
+Example output:
+
+```text
+Provider: openai
+Configured: yes
+Path: /home/user/.config/terminal-agent/auth.json
+Auth type: api_key
+Source: stored
+```
+
+If `OPENAI_API_KEY` is set in the environment, `Source` will show `environment` instead.
+
+### logout
+
+Remove stored credentials for a provider:
+
+```sh
+agent auth logout openai
+```
+
+This removes the entry from `~/.config/terminal-agent/auth.json`. It does not unset environment variables.
+
+## Credential Storage
+
+Credentials are stored in:
+
+```
+~/.config/terminal-agent/auth.json
+```
+
+The file is created with `0600` permissions and uses atomic writes to avoid data corruption.
+
+## Auth Resolution
+
+When the agent needs an OpenAI credential at runtime, it resolves in this order:
+
+1. `OPENAI_API_KEY` environment variable — highest priority
+2. Stored API key in `auth.json`
+3. Stored OAuth credential in `auth.json`
+4. Error: authentication not configured
+
+This means you can have stored credentials as a default and temporarily override them by setting `OPENAI_API_KEY`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,6 +145,13 @@ Example of storing an API key with the auth command:
 agent auth login openai --api-key
 ```
 
+Example of using OAuth-based login instead:
+
+```sh
+agent auth login openai          # browser OAuth login
+agent auth login openai --device # device-code login
+```
+
 **Auth resolution order for OpenAI:** `OPENAI_API_KEY` env var → stored API key in auth.json → stored OAuth credential → error.
 
 For the `llama` provider, example runtime setup is:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,22 +118,34 @@ When prompted to execute an action, you can respond with:
 
 ## Environment Variables
 
-Terminal Agent uses environment variables for API keys:
+Terminal Agent supports two credential sources:
 
-| Provider | Environment Variable | Description |
-|----------|---------------------|-------------|
-| OpenAI | `OPENAI_API_KEY` | API key for OpenAI services |
-| Anthropic | `ANTHROPIC_API_KEY` | API key for Anthropic Claude models |
-| Google | `GOOGLE_API_KEY` | API key for Google AI (Gemini) |
-| AWS Bedrock | AWS credentials | Standard AWS credential configuration |
-| Llama.cpp | `YZMA_LIB` | Path to the directory containing the local llama.cpp shared libraries used by the `llama` provider |
-| Ollama | `OLLAMA_HOST` | Host URL for Ollama server |
+**Environment variables** and **stored credentials** in `~/.config/terminal-agent/auth.json`.
+
+Stored credentials are managed with the `agent auth` command and take effect automatically when the corresponding environment variable is unset.
+
+| Provider | Environment Variable | Auth File | Description |
+|----------|---------------------|-----------|-------------|
+| OpenAI | `OPENAI_API_KEY` | supported | API key or stored credential for OpenAI services |
+| Anthropic | `ANTHROPIC_API_KEY` | — | API key for Anthropic Claude models |
+| Google | `GOOGLE_API_KEY` | — | API key for Google AI (Gemini) |
+| AWS Bedrock | AWS credentials | — | Standard AWS credential configuration |
+| Llama.cpp | `YZMA_LIB` | — | Path to the directory containing the local llama.cpp shared libraries used by the `llama` provider |
+| Ollama | `OLLAMA_HOST` | — | Host URL for Ollama server |
 
 Example of setting an environment variable:
 
 ```sh
 export OPENAI_API_KEY=your_api_key_here
 ```
+
+Example of storing an API key with the auth command:
+
+```sh
+agent auth login openai --api-key
+```
+
+**Auth resolution order for OpenAI:** `OPENAI_API_KEY` env var → stored API key in auth.json → stored OAuth credential → error.
 
 For the `llama` provider, example runtime setup is:
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -95,10 +95,14 @@ OpenAI supports two methods to set up authentication: an API key (traditional), 
 
 Store your API key or authenticate with your ChatGPT subscription:
 ```sh
+agent auth login openai               # browser OAuth login
+agent auth login openai --device      # terminal-friendly device login
 agent auth login openai --api-key     # store an API key
 ```
 
-Credentials are persisted in `~/.config/terminal-agent/auth.json`. They are used automatically for `ask`, `chat`, and `task` commands when no `OPENAI_API_KEY` environment variable is present.
+Credentials are persisted in `~/.config/terminal-agent/auth.json`. They are used automatically for `ask`, `chat`, and `task` commands when no `OPENAI_API_KEY` environment variable is present. Stored OAuth tokens refresh automatically while a valid refresh token is still available.
+
+If the browser callback does not complete automatically, `agent auth login openai` also accepts a pasted authorization code or full redirect URL as a fallback.
 
 Check your auth status at any time:
 ```sh

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -80,13 +80,35 @@ Example config:
 
 ### OpenAI
 
-**Setup:**
+OpenAI supports two methods to set up authentication: an API key (traditional), or stored credentials via `agent auth`.
+
+**Option 1: API key via environment variable**
+
 1. Create an account at [OpenAI](https://platform.openai.com/)
 2. Generate an API key
 3. Set the key as an environment variable:
    ```sh
    export OPENAI_API_KEY=your_api_key_here
    ```
+
+**Option 2: Stored credentials via agent auth**
+
+Store your API key or authenticate with your ChatGPT subscription:
+```sh
+agent auth login openai --api-key     # store an API key
+```
+
+Credentials are persisted in `~/.config/terminal-agent/auth.json`. They are used automatically for `ask`, `chat`, and `task` commands when no `OPENAI_API_KEY` environment variable is present.
+
+Check your auth status at any time:
+```sh
+agent auth status openai
+```
+
+Remove stored credentials:
+```sh
+agent auth logout openai
+```
 
 **Configuration:**
 ```sh
@@ -109,6 +131,8 @@ export OPENAI_BASE_URL=https://your-custom-endpoint.com/v1
 - Supports streaming output with the `--stream` flag
 - Tool usage capability for the `task` command
 - Compatible with OpenAI-compatible endpoints via `OPENAI_BASE_URL`
+
+**Auth resolution order:** When both a stored credential and `OPENAI_API_KEY` exist, the environment variable takes precedence.
 
 ### Anthropic
 

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -1,0 +1,123 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+var (
+	ErrAuthNotConfigured     = errors.New("OpenAI authentication not configured. Set OPENAI_API_KEY or run 'agent auth login openai --api-key'.")
+	ErrOpenAIOAuthConfigured = errors.New("Stored OpenAI OAuth login is configured, but the OpenAI Codex runtime integration is not implemented yet.")
+	ErrUnsupportedCredential = errors.New("unsupported stored auth credential")
+	ErrUnsupportedProvider   = errors.New("unsupported auth provider")
+)
+
+func NormalizeProvider(provider string) string {
+	return strings.TrimSpace(strings.ToLower(provider))
+}
+
+func ValidateProvider(provider string) error {
+	if NormalizeProvider(provider) != ProviderOpenAI {
+		return fmt.Errorf("%w: %s", ErrUnsupportedProvider, provider)
+	}
+	return nil
+}
+
+func (m *Manager) SaveAPIKey(provider, key string) error {
+	if err := ValidateProvider(provider); err != nil {
+		return err
+	}
+
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return fmt.Errorf("API key cannot be empty")
+	}
+
+	return m.SaveProvider(NormalizeProvider(provider), Credential{
+		Type: CredentialTypeAPIKey,
+		Key:  trimmed,
+	})
+}
+
+func (m *Manager) Status(provider string) (Status, error) {
+	if err := ValidateProvider(provider); err != nil {
+		return Status{}, err
+	}
+
+	status := Status{
+		Provider: NormalizeProvider(provider),
+		Path:     m.path,
+	}
+
+	credential, source, configured, err := m.lookupOpenAICredential()
+	if err != nil {
+		return Status{}, err
+	}
+	if !configured {
+		return status, nil
+	}
+
+	status.Type = credential.Type
+	status.Source = source
+	status.Configured = configured
+	status.AccountID = credential.AccountID
+	status.PlanType = credential.PlanType
+
+	if credential.Type == CredentialTypeOAuth && credential.Expires > 0 {
+		status.ExpiresAt = time.UnixMilli(credential.Expires)
+		status.Expired = time.Now().After(status.ExpiresAt)
+	}
+
+	return status, nil
+}
+
+func (m *Manager) ResolveOpenAIAPIKeyAuth() (ResolvedAuth, error) {
+	credential, source, configured, err := m.lookupOpenAICredential()
+	if err != nil {
+		return ResolvedAuth{}, err
+	}
+	if !configured {
+		return ResolvedAuth{}, ErrAuthNotConfigured
+	}
+
+	switch credential.Type {
+	case CredentialTypeAPIKey:
+		if strings.TrimSpace(credential.Key) == "" {
+			return ResolvedAuth{}, ErrAuthNotConfigured
+		}
+		return ResolvedAuth{
+			Provider: ProviderOpenAI,
+			Type:     CredentialTypeAPIKey,
+			Source:   source,
+			Token:    credential.Key,
+		}, nil
+	case CredentialTypeOAuth:
+		return ResolvedAuth{}, ErrOpenAIOAuthConfigured
+	default:
+		return ResolvedAuth{}, fmt.Errorf("%w: %s", ErrUnsupportedCredential, credential.Type)
+	}
+}
+
+func (m *Manager) lookupOpenAICredential() (Credential, string, bool, error) {
+	if envKey := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); envKey != "" {
+		return Credential{
+			Type: CredentialTypeAPIKey,
+			Key:  envKey,
+		}, SourceEnvironment, true, nil
+	}
+
+	authFile, err := m.Load()
+	if err != nil {
+		return Credential{}, "", false, err
+	}
+
+	credential, exists := authFile[ProviderOpenAI]
+	if !exists {
+		return Credential{}, "", false, nil
+	}
+
+	return credential, SourceStored, true, nil
+}

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -10,7 +10,8 @@ import (
 
 var (
 	ErrAuthNotConfigured     = errors.New("OpenAI authentication not configured. Set OPENAI_API_KEY or run 'agent auth login openai --api-key'.")
-	ErrOpenAIOAuthConfigured = errors.New("Stored OpenAI OAuth login is configured, but the OpenAI Codex runtime integration is not implemented yet.")
+	ErrOpenAIOAuthConfigured = errors.New("Stored OpenAI OAuth login is configured. This code path only supports API-key auth resolution.")
+	ErrOpenAIOAuthExpired    = errors.New("Stored OpenAI OAuth login could not be refreshed. Run 'agent auth login openai' again.")
 	ErrUnsupportedCredential = errors.New("unsupported stored auth credential")
 	ErrUnsupportedProvider   = errors.New("unsupported auth provider")
 )
@@ -75,6 +76,17 @@ func (m *Manager) Status(provider string) (Status, error) {
 }
 
 func (m *Manager) ResolveOpenAIAPIKeyAuth() (ResolvedAuth, error) {
+	credential, _, configured, err := m.lookupOpenAICredential()
+	if err != nil {
+		return ResolvedAuth{}, err
+	}
+	if configured && credential.Type == CredentialTypeOAuth {
+		return ResolvedAuth{}, ErrOpenAIOAuthConfigured
+	}
+	return m.ResolveOpenAIAuth()
+}
+
+func (m *Manager) ResolveOpenAIAuth() (ResolvedAuth, error) {
 	credential, source, configured, err := m.lookupOpenAICredential()
 	if err != nil {
 		return ResolvedAuth{}, err
@@ -95,7 +107,32 @@ func (m *Manager) ResolveOpenAIAPIKeyAuth() (ResolvedAuth, error) {
 			Token:    credential.Key,
 		}, nil
 	case CredentialTypeOAuth:
-		return ResolvedAuth{}, ErrOpenAIOAuthConfigured
+		refreshedCredential, _, err := m.refreshOpenAIOAuthIfNeeded()
+		if err != nil {
+			return ResolvedAuth{}, err
+		}
+		if strings.TrimSpace(refreshedCredential.Access) == "" {
+			return ResolvedAuth{}, ErrAuthNotConfigured
+		}
+		expiresAt := time.Time{}
+		expired := false
+		if refreshedCredential.Expires > 0 {
+			expiresAt = time.UnixMilli(refreshedCredential.Expires)
+			expired = openAIOAuthNeedsRefresh(refreshedCredential, time.Now())
+		}
+		if strings.TrimSpace(refreshedCredential.AccountID) == "" {
+			return ResolvedAuth{}, fmt.Errorf("stored OpenAI OAuth credential is missing account metadata; run 'agent auth login openai' again")
+		}
+		return ResolvedAuth{
+			Provider:  ProviderOpenAI,
+			Type:      CredentialTypeOAuth,
+			Source:    source,
+			Token:     refreshedCredential.Access,
+			AccountID: refreshedCredential.AccountID,
+			PlanType:  refreshedCredential.PlanType,
+			ExpiresAt: expiresAt,
+			Expired:   expired,
+		}, nil
 	default:
 		return ResolvedAuth{}, fmt.Errorf("%w: %s", ErrUnsupportedCredential, credential.Type)
 	}

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -1,0 +1,144 @@
+package auth
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	t.Setenv("OPENAI_API_KEY", "")
+	return NewManagerWithPath(filepath.Join(t.TempDir(), "auth.json"))
+}
+
+func TestLoadMissingFileReturnsEmpty(t *testing.T) {
+	mgr := newTestManager(t)
+
+	authFile, err := mgr.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(authFile) != 0 {
+		t.Fatalf("expected empty auth file, got %#v", authFile)
+	}
+}
+
+func TestSaveAPIKeyAndStatus(t *testing.T) {
+	mgr := newTestManager(t)
+
+	if err := mgr.SaveAPIKey(ProviderOpenAI, "sk-test"); err != nil {
+		t.Fatalf("SaveAPIKey() error = %v", err)
+	}
+
+	status, err := mgr.Status(ProviderOpenAI)
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if !status.Configured {
+		t.Fatal("expected configured status")
+	}
+	if status.Type != CredentialTypeAPIKey {
+		t.Fatalf("status.Type = %q, want %q", status.Type, CredentialTypeAPIKey)
+	}
+	if status.Source != SourceStored {
+		t.Fatalf("status.Source = %q, want %q", status.Source, SourceStored)
+	}
+
+	info, err := os.Stat(mgr.Path())
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("file mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestResolveOpenAIAPIKeyAuthPrefersEnvironment(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := mgr.SaveAPIKey(ProviderOpenAI, "sk-stored"); err != nil {
+		t.Fatalf("SaveAPIKey() error = %v", err)
+	}
+
+	t.Setenv("OPENAI_API_KEY", "sk-env")
+
+	resolved, err := mgr.ResolveOpenAIAPIKeyAuth()
+	if err != nil {
+		t.Fatalf("ResolveOpenAIAPIKeyAuth() error = %v", err)
+	}
+	if resolved.Source != SourceEnvironment {
+		t.Fatalf("resolved.Source = %q, want %q", resolved.Source, SourceEnvironment)
+	}
+	if resolved.Token != "sk-env" {
+		t.Fatalf("resolved.Token = %q, want %q", resolved.Token, "sk-env")
+	}
+}
+
+func TestResolveOpenAIAPIKeyAuthReturnsStoredAPIKey(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := mgr.SaveAPIKey(ProviderOpenAI, "sk-stored"); err != nil {
+		t.Fatalf("SaveAPIKey() error = %v", err)
+	}
+
+	resolved, err := mgr.ResolveOpenAIAPIKeyAuth()
+	if err != nil {
+		t.Fatalf("ResolveOpenAIAPIKeyAuth() error = %v", err)
+	}
+	if resolved.Source != SourceStored {
+		t.Fatalf("resolved.Source = %q, want %q", resolved.Source, SourceStored)
+	}
+	if resolved.Token != "sk-stored" {
+		t.Fatalf("resolved.Token = %q, want %q", resolved.Token, "sk-stored")
+	}
+}
+
+func TestResolveOpenAIAPIKeyAuthReturnsOAuthNotSupported(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := mgr.SaveProvider(ProviderOpenAI, Credential{
+		Type:    CredentialTypeOAuth,
+		Access:  "access-token",
+		Refresh: "refresh-token",
+		Expires: time.Now().Add(time.Hour).UnixMilli(),
+	}); err != nil {
+		t.Fatalf("SaveProvider() error = %v", err)
+	}
+
+	_, err := mgr.ResolveOpenAIAPIKeyAuth()
+	if !errors.Is(err, ErrOpenAIOAuthConfigured) {
+		t.Fatalf("ResolveOpenAIAPIKeyAuth() error = %v, want %v", err, ErrOpenAIOAuthConfigured)
+	}
+}
+
+func TestDeleteProvider(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := mgr.SaveAPIKey(ProviderOpenAI, "sk-stored"); err != nil {
+		t.Fatalf("SaveAPIKey() error = %v", err)
+	}
+
+	deleted, err := mgr.DeleteProvider(ProviderOpenAI)
+	if err != nil {
+		t.Fatalf("DeleteProvider() error = %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected provider to be deleted")
+	}
+
+	status, err := mgr.Status(ProviderOpenAI)
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if status.Configured {
+		t.Fatalf("expected provider to be unconfigured after delete, got %#v", status)
+	}
+}
+
+func TestResolveOpenAIAPIKeyAuthReturnsNotConfigured(t *testing.T) {
+	mgr := newTestManager(t)
+
+	_, err := mgr.ResolveOpenAIAPIKeyAuth()
+	if !errors.Is(err, ErrAuthNotConfigured) {
+		t.Fatalf("ResolveOpenAIAPIKeyAuth() error = %v, want %v", err, ErrAuthNotConfigured)
+	}
+}

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -111,6 +111,53 @@ func TestResolveOpenAIAPIKeyAuthReturnsOAuthNotSupported(t *testing.T) {
 	}
 }
 
+func TestResolveOpenAIAuthReturnsStoredOAuth(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := mgr.SaveProvider(ProviderOpenAI, Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    "access-token",
+		Refresh:   "refresh-token",
+		Expires:   time.Now().Add(time.Hour).UnixMilli(),
+		AccountID: "workspace-1",
+		PlanType:  "pro",
+	}); err != nil {
+		t.Fatalf("SaveProvider() error = %v", err)
+	}
+
+	resolved, err := mgr.ResolveOpenAIAuth()
+	if err != nil {
+		t.Fatalf("ResolveOpenAIAuth() error = %v", err)
+	}
+	if resolved.Type != CredentialTypeOAuth {
+		t.Fatalf("resolved.Type = %q, want %q", resolved.Type, CredentialTypeOAuth)
+	}
+	if resolved.AccountID != "workspace-1" {
+		t.Fatalf("resolved.AccountID = %q, want %q", resolved.AccountID, "workspace-1")
+	}
+}
+
+func TestResolveOpenAIAuthRejectsExpiredStoredOAuth(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := mgr.SaveProvider(ProviderOpenAI, Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    "access-token",
+		Refresh:   "refresh-token",
+		Expires:   time.Now().Add(-time.Minute).UnixMilli(),
+		AccountID: "workspace-1",
+	}); err != nil {
+		t.Fatalf("SaveProvider() error = %v", err)
+	}
+
+	originalTokenEndpoint := openAITokenEndpoint
+	openAITokenEndpoint = "http://127.0.0.1:1"
+	defer func() { openAITokenEndpoint = originalTokenEndpoint }()
+
+	_, err := mgr.ResolveOpenAIAuth()
+	if err == nil {
+		t.Fatal("expected refresh failure for expired stored OAuth")
+	}
+}
+
 func TestDeleteProvider(t *testing.T) {
 	mgr := newTestManager(t)
 	if err := mgr.SaveAPIKey(ProviderOpenAI, "sk-stored"); err != nil {

--- a/internal/auth/openai_browser.go
+++ b/internal/auth/openai_browser.go
@@ -1,0 +1,367 @@
+package auth
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	openAIIssuer          = "https://auth.openai.com"
+	openAIAuthorizeURL    = "https://auth.openai.com/oauth/authorize"
+	openAITokenURL        = "https://auth.openai.com/oauth/token"
+	openAIClientID        = "app_EMoamEEZ73f0CkXaXp7hrann"
+	openAICallbackHost    = "127.0.0.1"
+	openAICallbackPort    = 1455
+	openAICallbackPortAlt = 1457
+	openAICallbackPath    = "/auth/callback"
+	openAIScope           = "openid profile email offline_access api.connectors.read api.connectors.invoke"
+	openAIOriginator      = "terminal-agent"
+
+	jwtClaimPath = "https://api.openai.com/auth"
+)
+
+type OpenAITokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	IDToken      string `json:"id_token,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+type OAuthResult struct {
+	Access    string
+	Refresh   string
+	Expires   int64
+	AccountID string
+	PlanType  string
+}
+
+type BrowserLoginConfig struct {
+	OpenBrowser bool
+	Originator  string
+}
+
+func DefaultBrowserLoginConfig() BrowserLoginConfig {
+	return BrowserLoginConfig{
+		OpenBrowser: true,
+		Originator:  openAIOriginator,
+	}
+}
+
+func buildAuthorizeURL(redirectURI, codeChallenge, state, originator string) string {
+	u, _ := url.Parse(openAIAuthorizeURL)
+	q := u.Query()
+	q.Set("response_type", "code")
+	q.Set("client_id", openAIClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", openAIScope)
+	q.Set("code_challenge", codeChallenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", state)
+	q.Set("id_token_add_organizations", "true")
+	q.Set("codex_cli_simplified_flow", "true")
+	q.Set("originator", originator)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func (m *Manager) LoginOpenAIBrowser(cfg BrowserLoginConfig) (*OAuthResult, error) {
+	pkce, err := GeneratePKCE()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate PKCE: %w", err)
+	}
+
+	state, err := GenerateState()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate state: %w", err)
+	}
+
+	callbackPort, err := bindCallbackServer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind callback server: %w", err)
+	}
+
+	redirectURI := fmt.Sprintf("http://localhost:%d%s", callbackPort, openAICallbackPath)
+	authURL := buildAuthorizeURL(redirectURI, pkce.CodeChallenge, state, cfg.Originator)
+
+	fmt.Fprintf(os.Stderr, "\nOpen this URL in your browser to authenticate:\n\n%s\n\n", authURL)
+	fmt.Fprintln(os.Stderr, "If the callback does not return automatically, paste the authorization code or full redirect URL here and press Enter.")
+	if cfg.OpenBrowser {
+		openBrowser(authURL)
+	}
+
+	code, err := waitForAuthCode(callbackPort, state)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := exchangeCodeForTokens(code, pkce.CodeVerifier, redirectURI, cfg.Originator)
+	if err != nil {
+		return nil, err
+	}
+
+	expiresAt := time.Now().UnixMilli() + result.ExpiresIn*1000
+
+	if err := m.SaveProvider(ProviderOpenAI, Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    result.AccessToken,
+		Refresh:   result.RefreshToken,
+		Expires:   expiresAt,
+		AccountID: result.AccountID,
+		PlanType:  result.PlanType,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to persist OAuth credential: %w", err)
+	}
+
+	return &OAuthResult{
+		Access:    result.AccessToken,
+		Refresh:   result.RefreshToken,
+		Expires:   expiresAt,
+		AccountID: result.AccountID,
+		PlanType:  result.PlanType,
+	}, nil
+}
+
+func bindCallbackServer() (int, error) {
+	for _, port := range []int{openAICallbackPort, openAICallbackPortAlt} {
+		addr := fmt.Sprintf("%s:%d", openAICallbackHost, port)
+		listener, err := net.Listen("tcp", addr)
+		if err == nil {
+			listener.Close()
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("callback ports %d and %d are both unavailable", openAICallbackPort, openAICallbackPortAlt)
+}
+
+func waitForAuthCode(port int, expectedState string) (string, error) {
+	mux := http.NewServeMux()
+
+	type callbackResult struct {
+		code string
+		err  error
+	}
+	resultCh := make(chan callbackResult, 1)
+	manualResultCh := make(chan callbackResult, 1)
+
+	mux.HandleFunc(openAICallbackPath, func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+
+		if q.Get("state") != expectedState {
+			http.Error(w, "State mismatch", http.StatusBadRequest)
+			resultCh <- callbackResult{err: fmt.Errorf("OAuth callback state mismatch")}
+			return
+		}
+
+		code := q.Get("code")
+		if code == "" {
+			http.Error(w, "Missing authorization code", http.StatusBadRequest)
+			resultCh <- callbackResult{err: fmt.Errorf("OAuth callback missing authorization code")}
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `<html><body><h1>Terminal Agent</h1><p>Authentication completed. You can close this window.</p></body></html>`)
+
+		resultCh <- callbackResult{code: code}
+	})
+
+	addr := fmt.Sprintf("%s:%d", openAICallbackHost, port)
+	srv := &http.Server{Addr: addr, Handler: mux}
+
+	go func() {
+		_ = srv.ListenAndServe()
+	}()
+
+	go func() {
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			input := strings.TrimSpace(scanner.Text())
+			if input == "" {
+				continue
+			}
+
+			code, state := ParseAuthorizationInput(input)
+			if state != "" && state != expectedState {
+				manualResultCh <- callbackResult{err: fmt.Errorf("OAuth manual input state mismatch")}
+				return
+			}
+			if code == "" {
+				manualResultCh <- callbackResult{err: fmt.Errorf("OAuth manual input missing authorization code")}
+				return
+			}
+
+			manualResultCh <- callbackResult{code: code}
+			return
+		}
+		if err := scanner.Err(); err != nil {
+			manualResultCh <- callbackResult{err: fmt.Errorf("failed to read manual OAuth input: %w", err)}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	select {
+	case result := <-resultCh:
+		return result.code, result.err
+	case result := <-manualResultCh:
+		return result.code, result.err
+	case <-ctx.Done():
+		return "", fmt.Errorf("OAuth login timed out; no callback received within 5 minutes")
+	}
+}
+
+type oauthTokenExchangeResult struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    int64
+	AccountID    string
+	PlanType     string
+}
+
+func exchangeCodeForTokens(code, codeVerifier, redirectURI, originator string) (*oauthTokenExchangeResult, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", openAIClientID)
+	form.Set("code", code)
+	form.Set("code_verifier", codeVerifier)
+	form.Set("redirect_uri", redirectURI)
+
+	req, err := http.NewRequest(http.MethodPost, openAITokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token exchange request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("token endpoint returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var tokenResp OpenAITokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" || tokenResp.RefreshToken == "" || tokenResp.ExpiresIn == 0 {
+		return nil, fmt.Errorf("token response missing required fields (access_token, refresh_token, expires_in)")
+	}
+
+	accountID, planType := extractJWTAccountMetadata(tokenResp.AccessToken)
+
+	return &oauthTokenExchangeResult{
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		ExpiresIn:    tokenResp.ExpiresIn,
+		AccountID:    accountID,
+		PlanType:     planType,
+	}, nil
+}
+
+func extractJWTAccountMetadata(accessToken string) (accountID, planType string) {
+	payload, err := decodeJWTPayload(accessToken)
+	if err != nil {
+		return "", ""
+	}
+
+	authClaim, ok := payload[jwtClaimPath]
+	if !ok {
+		return "", ""
+	}
+
+	authMap, ok := authClaim.(map[string]any)
+	if !ok {
+		return "", ""
+	}
+
+	if aid, ok := authMap["chatgpt_account_id"].(string); ok {
+		accountID = aid
+	}
+
+	if pt, ok := authMap["chatgpt_plan_type"].(string); ok {
+		planType = pt
+	}
+
+	return accountID, planType
+}
+
+func decodeJWTPayload(token string) (map[string]any, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT format")
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode JWT payload: %w", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse JWT payload: %w", err)
+	}
+
+	return payload, nil
+}
+
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		return
+	}
+	_ = cmd.Start()
+}
+
+func ParseAuthorizationInput(input string) (code, state string) {
+	val := strings.TrimSpace(input)
+	if val == "" {
+		return "", ""
+	}
+
+	if u, err := url.Parse(val); err == nil && u.Scheme != "" {
+		return u.Query().Get("code"), u.Query().Get("state")
+	}
+
+	if idx := strings.IndexByte(val, '#'); idx != -1 {
+		code := val[:idx]
+		state := val[idx+1:]
+		return code, state
+	}
+
+	if strings.Contains(val, "code=") {
+		q, _ := url.ParseQuery(val)
+		return q.Get("code"), q.Get("state")
+	}
+
+	return val, ""
+}

--- a/internal/auth/openai_browser.go
+++ b/internal/auth/openai_browser.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -50,9 +51,12 @@ type OAuthResult struct {
 }
 
 type BrowserLoginConfig struct {
-	OpenBrowser bool
-	Originator  string
+	OpenBrowser      bool
+	Originator       string
+	ManualCodeReader io.Reader
 }
+
+var errOAuthCallbackTimeout = errors.New("OAuth login timed out; no callback received within 5 minutes")
 
 func DefaultBrowserLoginConfig() BrowserLoginConfig {
 	return BrowserLoginConfig{
@@ -62,7 +66,10 @@ func DefaultBrowserLoginConfig() BrowserLoginConfig {
 }
 
 func buildAuthorizeURL(redirectURI, codeChallenge, state, originator string) string {
-	u, _ := url.Parse(openAIAuthorizeURL)
+	u, err := url.Parse(openAIAuthorizeURL)
+	if err != nil {
+		return openAIAuthorizeURL
+	}
 	q := u.Query()
 	q.Set("response_type", "code")
 	q.Set("client_id", openAIClientID)
@@ -89,21 +96,28 @@ func (m *Manager) LoginOpenAIBrowser(cfg BrowserLoginConfig) (*OAuthResult, erro
 		return nil, fmt.Errorf("failed to generate state: %w", err)
 	}
 
-	callbackPort, err := bindCallbackServer()
+	listener, callbackPort, err := bindCallbackServer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to bind callback server: %w", err)
 	}
+	defer listener.Close()
 
 	redirectURI := fmt.Sprintf("http://localhost:%d%s", callbackPort, openAICallbackPath)
 	authURL := buildAuthorizeURL(redirectURI, pkce.CodeChallenge, state, cfg.Originator)
 
 	fmt.Fprintf(os.Stderr, "\nOpen this URL in your browser to authenticate:\n\n%s\n\n", authURL)
-	fmt.Fprintln(os.Stderr, "If the callback does not return automatically, paste the authorization code or full redirect URL here and press Enter.")
+	if cfg.ManualCodeReader != nil {
+		fmt.Fprintln(os.Stderr, "If the callback does not return automatically, you will be prompted to paste the authorization code or full redirect URL.")
+	}
 	if cfg.OpenBrowser {
 		openBrowser(authURL)
 	}
 
-	code, err := waitForAuthCode(callbackPort, state)
+	code, err := waitForAuthCode(listener, state)
+	if err != nil && errors.Is(err, errOAuthCallbackTimeout) && cfg.ManualCodeReader != nil {
+		fmt.Fprintln(os.Stderr, "Paste the authorization code or full redirect URL:")
+		code, err = promptManualAuthorizationInput(cfg.ManualCodeReader, state)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -135,19 +149,18 @@ func (m *Manager) LoginOpenAIBrowser(cfg BrowserLoginConfig) (*OAuthResult, erro
 	}, nil
 }
 
-func bindCallbackServer() (int, error) {
+func bindCallbackServer() (net.Listener, int, error) {
 	for _, port := range []int{openAICallbackPort, openAICallbackPortAlt} {
 		addr := fmt.Sprintf("%s:%d", openAICallbackHost, port)
 		listener, err := net.Listen("tcp", addr)
 		if err == nil {
-			listener.Close()
-			return port, nil
+			return listener, port, nil
 		}
 	}
-	return 0, fmt.Errorf("callback ports %d and %d are both unavailable", openAICallbackPort, openAICallbackPortAlt)
+	return nil, 0, fmt.Errorf("callback ports %d and %d are both unavailable", openAICallbackPort, openAICallbackPortAlt)
 }
 
-func waitForAuthCode(port int, expectedState string) (string, error) {
+func waitForAuthCode(listener net.Listener, expectedState string) (string, error) {
 	mux := http.NewServeMux()
 
 	type callbackResult struct {
@@ -155,7 +168,6 @@ func waitForAuthCode(port int, expectedState string) (string, error) {
 		err  error
 	}
 	resultCh := make(chan callbackResult, 1)
-	manualResultCh := make(chan callbackResult, 1)
 
 	mux.HandleFunc(openAICallbackPath, func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
@@ -180,37 +192,10 @@ func waitForAuthCode(port int, expectedState string) (string, error) {
 		resultCh <- callbackResult{code: code}
 	})
 
-	addr := fmt.Sprintf("%s:%d", openAICallbackHost, port)
-	srv := &http.Server{Addr: addr, Handler: mux}
+	srv := &http.Server{Handler: mux}
 
 	go func() {
-		_ = srv.ListenAndServe()
-	}()
-
-	go func() {
-		scanner := bufio.NewScanner(os.Stdin)
-		for scanner.Scan() {
-			input := strings.TrimSpace(scanner.Text())
-			if input == "" {
-				continue
-			}
-
-			code, state := ParseAuthorizationInput(input)
-			if state != "" && state != expectedState {
-				manualResultCh <- callbackResult{err: fmt.Errorf("OAuth manual input state mismatch")}
-				return
-			}
-			if code == "" {
-				manualResultCh <- callbackResult{err: fmt.Errorf("OAuth manual input missing authorization code")}
-				return
-			}
-
-			manualResultCh <- callbackResult{code: code}
-			return
-		}
-		if err := scanner.Err(); err != nil {
-			manualResultCh <- callbackResult{err: fmt.Errorf("failed to read manual OAuth input: %w", err)}
-		}
+		_ = srv.Serve(listener)
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -220,11 +205,32 @@ func waitForAuthCode(port int, expectedState string) (string, error) {
 	select {
 	case result := <-resultCh:
 		return result.code, result.err
-	case result := <-manualResultCh:
-		return result.code, result.err
 	case <-ctx.Done():
-		return "", fmt.Errorf("OAuth login timed out; no callback received within 5 minutes")
+		return "", errOAuthCallbackTimeout
 	}
+}
+
+func promptManualAuthorizationInput(reader io.Reader, expectedState string) (string, error) {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		input := strings.TrimSpace(scanner.Text())
+		if input == "" {
+			continue
+		}
+
+		code, state := ParseAuthorizationInput(input)
+		if state != "" && state != expectedState {
+			return "", fmt.Errorf("OAuth manual input state mismatch")
+		}
+		if code == "" {
+			return "", fmt.Errorf("OAuth manual input missing authorization code")
+		}
+		return code, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to read manual OAuth input: %w", err)
+	}
+	return "", fmt.Errorf("manual OAuth input ended before a code was provided")
 }
 
 type oauthTokenExchangeResult struct {

--- a/internal/auth/openai_browser_test.go
+++ b/internal/auth/openai_browser_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -179,11 +180,29 @@ func TestExtractJWTAccountMetadata(t *testing.T) {
 }
 
 func TestBindCallbackServer_FindsAvailablePort(t *testing.T) {
-	port, err := bindCallbackServer()
+	listener, port, err := bindCallbackServer()
 	if err != nil {
 		t.Fatalf("bindCallbackServer() error = %v", err)
 	}
+	defer listener.Close()
 	if port != openAICallbackPort && port != openAICallbackPortAlt {
 		t.Fatalf("expected port %d or %d, got %d", openAICallbackPort, openAICallbackPortAlt, port)
+	}
+}
+
+func TestPromptManualAuthorizationInput(t *testing.T) {
+	code, err := promptManualAuthorizationInput(strings.NewReader("http://localhost:1455/auth/callback?code=abc123&state=mystate\n"), "mystate")
+	if err != nil {
+		t.Fatalf("promptManualAuthorizationInput() error = %v", err)
+	}
+	if code != "abc123" {
+		t.Fatalf("code = %q, want %q", code, "abc123")
+	}
+}
+
+func TestPromptManualAuthorizationInputRejectsStateMismatch(t *testing.T) {
+	_, err := promptManualAuthorizationInput(strings.NewReader("abc123#wrongstate\n"), "mystate")
+	if err == nil {
+		t.Fatal("expected state mismatch error")
 	}
 }

--- a/internal/auth/openai_browser_test.go
+++ b/internal/auth/openai_browser_test.go
@@ -1,0 +1,189 @@
+package auth
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"testing"
+)
+
+func TestGeneratePKCE(t *testing.T) {
+	pkce, err := GeneratePKCE()
+	if err != nil {
+		t.Fatalf("GeneratePKCE() error = %v", err)
+	}
+	if pkce.CodeVerifier == "" {
+		t.Fatal("expected non-empty verifier")
+	}
+	if pkce.CodeChallenge == "" {
+		t.Fatal("expected non-empty challenge")
+	}
+	if pkce.CodeVerifier == pkce.CodeChallenge {
+		t.Fatal("verifier and challenge should differ")
+	}
+	if len(pkce.CodeVerifier) < 43 {
+		t.Fatalf("verifier too short: %d", len(pkce.CodeVerifier))
+	}
+}
+
+func TestGenerateState(t *testing.T) {
+	s1, err := GenerateState()
+	if err != nil {
+		t.Fatalf("GenerateState() error = %v", err)
+	}
+	s2, err := GenerateState()
+	if err != nil {
+		t.Fatalf("GenerateState() error = %v", err)
+	}
+	if s1 == "" || s2 == "" {
+		t.Fatal("expected non-empty state")
+	}
+	if s1 == s2 {
+		t.Fatal("states should be different")
+	}
+}
+
+func TestBuildAuthorizeURL(t *testing.T) {
+	raw := buildAuthorizeURL(
+		"http://localhost:1455/auth/callback",
+		"challenge",
+		"state",
+		"terminal-agent",
+	)
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+
+	q := u.Query()
+
+	if q.Get("response_type") != "code" {
+		t.Errorf("response_type = %q, want %q", q.Get("response_type"), "code")
+	}
+	if q.Get("client_id") != openAIClientID {
+		t.Errorf("client_id = %q, want %q", q.Get("client_id"), openAIClientID)
+	}
+	if q.Get("redirect_uri") != "http://localhost:1455/auth/callback" {
+		t.Errorf("redirect_uri = %q", q.Get("redirect_uri"))
+	}
+	if q.Get("code_challenge") != "challenge" {
+		t.Errorf("code_challenge = %q, want %q", q.Get("code_challenge"), "challenge")
+	}
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("code_challenge_method = %q", q.Get("code_challenge_method"))
+	}
+	if q.Get("state") != "state" {
+		t.Errorf("state = %q, want %q", q.Get("state"), "state")
+	}
+	if q.Get("id_token_add_organizations") != "true" {
+		t.Errorf("id_token_add_organizations = %q", q.Get("id_token_add_organizations"))
+	}
+	if q.Get("codex_cli_simplified_flow") != "true" {
+		t.Errorf("codex_cli_simplified_flow = %q", q.Get("codex_cli_simplified_flow"))
+	}
+	if q.Get("originator") != "terminal-agent" {
+		t.Errorf("originator = %q, want %q", q.Get("originator"), "terminal-agent")
+	}
+}
+
+func TestParseAuthorizationInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantCode  string
+		wantState string
+	}{
+		{"empty", "", "", ""},
+		{"raw code", "abc123", "abc123", ""},
+		{"full redirect URL", "http://localhost:1455/auth/callback?code=abc123&state=mystate", "abc123", "mystate"},
+		{"hash separator", "abc123#mystate", "abc123", "mystate"},
+		{"query string", "code=abc123&state=mystate", "abc123", "mystate"},
+		{"code only in query", "code=abc123", "abc123", ""},
+		{"whitespace around", "  code=abc123  ", "abc123", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, state := ParseAuthorizationInput(tc.input)
+			if code != tc.wantCode {
+				t.Errorf("code = %q, want %q", code, tc.wantCode)
+			}
+			if state != tc.wantState {
+				t.Errorf("state = %q, want %q", state, tc.wantState)
+			}
+		})
+	}
+}
+
+func TestDecodeJWTPayload(t *testing.T) {
+	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	sigB64 := base64.RawURLEncoding.EncodeToString([]byte(`sig`))
+
+	payload := fmt.Sprintf(`{"%s":{"chatgpt_account_id":"acc-1","chatgpt_plan_type":"pro"}}`, jwtClaimPath)
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	token := fmt.Sprintf("%s.%s.%s", headerB64, payloadB64, sigB64)
+
+	result, err := decodeJWTPayload(token)
+	if err != nil {
+		t.Fatalf("decodeJWTPayload() error = %v", err)
+	}
+
+	authClaim, ok := result[jwtClaimPath]
+	if !ok {
+		t.Fatal("expected auth claim")
+	}
+	authMap, ok := authClaim.(map[string]any)
+	if !ok {
+		t.Fatal("auth claim is not a map")
+	}
+	if authMap["chatgpt_account_id"] != "acc-1" {
+		t.Errorf("account_id = %v, want acc-1", authMap["chatgpt_account_id"])
+	}
+}
+
+func TestDecodeJWTPayload_MalformedToken(t *testing.T) {
+	_, err := decodeJWTPayload("not.a.jwt")
+	if err == nil {
+		t.Fatal("expected error for malformed token")
+	}
+}
+
+func TestDecodeJWTPayload_MissingAuthClaim(t *testing.T) {
+	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(`{}`))
+	sigB64 := base64.RawURLEncoding.EncodeToString([]byte(`sig`))
+	token := fmt.Sprintf("%s.%s.%s", headerB64, payloadB64, sigB64)
+
+	result, err := decodeJWTPayload(token)
+	if err != nil {
+		t.Fatalf("decodeJWTPayload() error = %v", err)
+	}
+	if _, ok := result[jwtClaimPath]; ok {
+		t.Fatal("expected no auth claim")
+	}
+}
+
+func TestExtractJWTAccountMetadata(t *testing.T) {
+	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	sigB64 := base64.RawURLEncoding.EncodeToString([]byte(`sig`))
+
+	payload := fmt.Sprintf(`{"%s":{"chatgpt_account_id":"ws-42"}}`, jwtClaimPath)
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	token := fmt.Sprintf("%s.%s.%s", headerB64, payloadB64, sigB64)
+
+	accountID, _ := extractJWTAccountMetadata(token)
+	if accountID != "ws-42" {
+		t.Errorf("accountID = %q, want %q", accountID, "ws-42")
+	}
+}
+
+func TestBindCallbackServer_FindsAvailablePort(t *testing.T) {
+	port, err := bindCallbackServer()
+	if err != nil {
+		t.Fatalf("bindCallbackServer() error = %v", err)
+	}
+	if port != openAICallbackPort && port != openAICallbackPortAlt {
+		t.Fatalf("expected port %d or %d, got %d", openAICallbackPort, openAICallbackPortAlt, port)
+	}
+}

--- a/internal/auth/openai_device.go
+++ b/internal/auth/openai_device.go
@@ -1,0 +1,265 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	deviceAuthUserCodePath = "/api/accounts/deviceauth/usercode"
+	deviceAuthTokenPath    = "/api/accounts/deviceauth/token"
+	deviceAuthCallbackPath = "/deviceauth/callback"
+	deviceVerificationPath = "/codex/device"
+)
+
+var deviceAuthTimeout = 15 * time.Minute
+
+type deviceUserCodeResponse struct {
+	DeviceAuthID string `json:"device_auth_id"`
+	UserCode     string `json:"user_code"`
+	Interval     int64  `json:"interval"`
+}
+
+func (r *deviceUserCodeResponse) UnmarshalJSON(data []byte) error {
+	type rawDeviceUserCodeResponse struct {
+		DeviceAuthID string          `json:"device_auth_id"`
+		UserCode     string          `json:"user_code"`
+		Interval     json.RawMessage `json:"interval"`
+	}
+
+	var raw rawDeviceUserCodeResponse
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	*r = deviceUserCodeResponse{
+		DeviceAuthID: raw.DeviceAuthID,
+		UserCode:     raw.UserCode,
+	}
+
+	if len(raw.Interval) == 0 || string(raw.Interval) == "null" {
+		return nil
+	}
+
+	var numericInterval int64
+	if err := json.Unmarshal(raw.Interval, &numericInterval); err == nil {
+		r.Interval = numericInterval
+		return nil
+	}
+
+	var stringInterval string
+	if err := json.Unmarshal(raw.Interval, &stringInterval); err == nil {
+		parsed, parseErr := strconv.ParseInt(strings.TrimSpace(stringInterval), 10, 64)
+		if parseErr != nil {
+			return fmt.Errorf("invalid device auth interval %q: %w", stringInterval, parseErr)
+		}
+		r.Interval = parsed
+		return nil
+	}
+
+	return fmt.Errorf("invalid device auth interval: %s", string(raw.Interval))
+}
+
+type deviceTokenRequest struct {
+	DeviceAuthID string `json:"device_auth_id"`
+	UserCode     string `json:"user_code"`
+}
+
+type deviceTokenResponse struct {
+	AuthorizationCode string `json:"authorization_code"`
+	CodeChallenge     string `json:"code_challenge"`
+	CodeVerifier      string `json:"code_verifier"`
+}
+
+func (m *Manager) LoginOpenAIDevice(cfg BrowserLoginConfig) (*OAuthResult, error) {
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	issuer := strings.TrimRight(openAIIssuer, "/")
+
+	deviceResp, err := requestDeviceUserCode(httpClient, issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	verificationURL := fmt.Sprintf("%s%s", issuer, deviceVerificationPath)
+
+	fmt.Fprintf(os.Stderr, "\nOpen this URL in your browser:\n\n%s\n\n", verificationURL)
+	fmt.Fprintf(os.Stderr, "Enter the following one-time code (expires in 15 minutes):\n\n%s\n\n", deviceResp.UserCode)
+	fmt.Fprintf(os.Stderr, "Never share this code. It is a common phishing target.\n\n")
+
+	tokenResp, err := pollDeviceToken(httpClient, issuer, deviceResp.DeviceAuthID, deviceResp.UserCode, deviceResp.Interval)
+	if err != nil {
+		return nil, err
+	}
+
+	redirectURI := issuer + deviceAuthCallbackPath
+
+	result, err := exchangeDeviceCodeForTokens(httpClient, issuer, tokenResp.AuthorizationCode, tokenResp.CodeVerifier, tokenResp.CodeChallenge, redirectURI, cfg.Originator)
+	if err != nil {
+		return nil, err
+	}
+
+	expiresAt := time.Now().UnixMilli() + result.ExpiresIn*1000
+
+	if err := m.SaveProvider(ProviderOpenAI, Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    result.AccessToken,
+		Refresh:   result.RefreshToken,
+		Expires:   expiresAt,
+		AccountID: result.AccountID,
+		PlanType:  result.PlanType,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to persist OAuth credential: %w", err)
+	}
+
+	return &OAuthResult{
+		Access:    result.AccessToken,
+		Refresh:   result.RefreshToken,
+		Expires:   expiresAt,
+		AccountID: result.AccountID,
+		PlanType:  result.PlanType,
+	}, nil
+}
+
+func requestDeviceUserCode(client *http.Client, issuer string) (*deviceUserCodeResponse, error) {
+	body, err := json.Marshal(map[string]string{"client_id": openAIClientID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode device auth request: %w", err)
+	}
+
+	resp, err := client.Post(issuer+deviceAuthUserCodePath, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("device auth request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("device code login is not enabled for this server; use browser login instead")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("device auth request returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+	}
+
+	var deviceResp deviceUserCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceResp); err != nil {
+		return nil, fmt.Errorf("failed to decode device auth response: %w", err)
+	}
+
+	if deviceResp.DeviceAuthID == "" || deviceResp.UserCode == "" {
+		return nil, fmt.Errorf("device auth response missing required fields")
+	}
+
+	if deviceResp.Interval <= 0 {
+		deviceResp.Interval = 5
+	}
+
+	return &deviceResp, nil
+}
+
+func pollDeviceToken(client *http.Client, issuer, deviceAuthID, userCode string, interval int64) (*deviceTokenResponse, error) {
+	pollBody, err := json.Marshal(deviceTokenRequest{
+		DeviceAuthID: deviceAuthID,
+		UserCode:     userCode,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode device poll request: %w", err)
+	}
+
+	deadline := time.Now().Add(deviceAuthTimeout)
+	sleepDuration := time.Duration(interval) * time.Second
+
+	for {
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("device auth timed out after 15 minutes")
+		}
+
+		time.Sleep(sleepDuration)
+
+		req, err := http.NewRequest(http.MethodPost, issuer+deviceAuthTokenPath, bytes.NewReader(pollBody))
+		if err != nil {
+			return nil, fmt.Errorf("failed to build device poll request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			var tokenResp deviceTokenResponse
+			if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+				resp.Body.Close()
+				continue
+			}
+			resp.Body.Close()
+
+			if tokenResp.AuthorizationCode == "" || tokenResp.CodeVerifier == "" {
+				continue
+			}
+
+			return &tokenResp, nil
+		}
+
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusNotFound {
+			return nil, fmt.Errorf("device auth polling returned unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+		}
+	}
+}
+
+func exchangeDeviceCodeForTokens(client *http.Client, issuer, authorizationCode, codeVerifier, codeChallenge, redirectURI, originator string) (*oauthTokenExchangeResult, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", openAIClientID)
+	form.Set("code", authorizationCode)
+	form.Set("code_verifier", codeVerifier)
+	form.Set("redirect_uri", redirectURI)
+
+	req, err := http.NewRequest(http.MethodPost, issuer+"/oauth/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build device token exchange request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("device token exchange request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("device token exchange returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var tokenResp OpenAITokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to decode device token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" || tokenResp.RefreshToken == "" || tokenResp.ExpiresIn == 0 {
+		return nil, fmt.Errorf("device token response missing required fields")
+	}
+
+	accountID, planType := extractJWTAccountMetadata(tokenResp.AccessToken)
+
+	return &oauthTokenExchangeResult{
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		ExpiresIn:    tokenResp.ExpiresIn,
+		AccountID:    accountID,
+		PlanType:     planType,
+	}, nil
+}

--- a/internal/auth/openai_device_test.go
+++ b/internal/auth/openai_device_test.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRequestDeviceUserCode_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != deviceAuthUserCodePath {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+
+		var body map[string]string
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["client_id"] != openAIClientID {
+			t.Errorf("client_id = %q, want %q", body["client_id"], openAIClientID)
+		}
+
+		json.NewEncoder(w).Encode(deviceUserCodeResponse{
+			DeviceAuthID: "dev-1",
+			UserCode:     "CODE42",
+			Interval:     5,
+		})
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := requestDeviceUserCode(client, ts.URL)
+	if err != nil {
+		t.Fatalf("requestDeviceUserCode() error = %v", err)
+	}
+	if resp.DeviceAuthID != "dev-1" {
+		t.Errorf("DeviceAuthID = %q, want %q", resp.DeviceAuthID, "dev-1")
+	}
+	if resp.UserCode != "CODE42" {
+		t.Errorf("UserCode = %q, want %q", resp.UserCode, "CODE42")
+	}
+	if resp.Interval != 5 {
+		t.Errorf("Interval = %d, want 5", resp.Interval)
+	}
+}
+
+func TestRequestDeviceUserCode_SuccessWithStringInterval(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"device_auth_id":"dev-2","user_code":"CODE99","interval":"7"}`))
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := requestDeviceUserCode(client, ts.URL)
+	if err != nil {
+		t.Fatalf("requestDeviceUserCode() error = %v", err)
+	}
+	if resp.Interval != 7 {
+		t.Fatalf("Interval = %d, want 7", resp.Interval)
+	}
+}
+
+func TestRequestDeviceUserCode_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := requestDeviceUserCode(client, ts.URL)
+	if err == nil {
+		t.Fatal("expected error for unsupported device flow")
+	}
+}
+
+func TestRequestDeviceUserCode_Non200(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := requestDeviceUserCode(client, ts.URL)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+func TestPollDeviceToken_Success(t *testing.T) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount < 3 {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		json.NewEncoder(w).Encode(deviceTokenResponse{
+			AuthorizationCode: "auth-code-1",
+			CodeChallenge:     "challenge-1",
+			CodeVerifier:      "verifier-1",
+		})
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := pollDeviceToken(client, ts.URL, "dev-1", "CODE42", 0)
+	if err != nil {
+		t.Fatalf("pollDeviceToken() error = %v", err)
+	}
+	if resp.AuthorizationCode != "auth-code-1" {
+		t.Errorf("AuthorizationCode = %q", resp.AuthorizationCode)
+	}
+	if resp.CodeVerifier != "verifier-1" {
+		t.Errorf("CodeVerifier = %q", resp.CodeVerifier)
+	}
+}
+
+func TestPollDeviceToken_Timeout(t *testing.T) {
+	originalTimeout := deviceAuthTimeout
+	deviceAuthTimeout = 1 * time.Millisecond
+	defer func() { deviceAuthTimeout = originalTimeout }()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := pollDeviceToken(client, ts.URL, "dev-1", "CODE42", 0)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+func TestPollDeviceToken_UnexpectedStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := pollDeviceToken(client, ts.URL, "dev-1", "CODE42", 1)
+	if err == nil {
+		t.Fatal("expected error for unexpected status")
+	}
+}

--- a/internal/auth/openai_refresh.go
+++ b/internal/auth/openai_refresh.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+func (m *Manager) refreshOpenAIOAuthIfNeeded() (Credential, bool, error) {
+	var refreshed bool
+	var resolved Credential
+	err := m.withLock(func() error {
+		authFile, err := m.loadUnlocked()
+		if err != nil {
+			return err
+		}
+
+		credential, exists := authFile[ProviderOpenAI]
+		if !exists {
+			return ErrAuthNotConfigured
+		}
+		if credential.Type != CredentialTypeOAuth {
+			resolved = credential
+			return nil
+		}
+
+		if !openAIOAuthNeedsRefresh(credential, time.Now()) {
+			resolved = credential
+			return nil
+		}
+		if strings.TrimSpace(credential.Refresh) == "" {
+			return ErrOpenAIOAuthExpired
+		}
+
+		updated, err := refreshOpenAIOAuthCredential(credential)
+		if err != nil {
+			return err
+		}
+
+		authFile[ProviderOpenAI] = updated
+		if err := m.saveUnlocked(authFile); err != nil {
+			return err
+		}
+
+		resolved = updated
+		refreshed = true
+		return nil
+	})
+	if err != nil {
+		return Credential{}, false, err
+	}
+	return resolved, refreshed, nil
+}
+
+func openAIOAuthNeedsRefresh(credential Credential, now time.Time) bool {
+	if credential.Type != CredentialTypeOAuth {
+		return false
+	}
+	if credential.Expires <= 0 {
+		return false
+	}
+	return !now.Before(time.UnixMilli(credential.Expires).Add(-OpenAIOAuthRefreshThreshold))
+}
+
+func refreshOpenAIOAuthCredential(credential Credential) (Credential, error) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", credential.Refresh)
+	form.Set("client_id", openAIClientID)
+
+	req, err := http.NewRequest(http.MethodPost, openAITokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return Credential{}, fmt.Errorf("failed to build OAuth refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return Credential{}, fmt.Errorf("OAuth refresh request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return Credential{}, fmt.Errorf("OAuth refresh returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var tokenResp OpenAITokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return Credential{}, fmt.Errorf("failed to decode OAuth refresh response: %w", err)
+	}
+	if tokenResp.AccessToken == "" || tokenResp.RefreshToken == "" || tokenResp.ExpiresIn == 0 {
+		return Credential{}, fmt.Errorf("OAuth refresh response missing required fields")
+	}
+
+	accountID, planType := extractJWTAccountMetadata(tokenResp.AccessToken)
+	if strings.TrimSpace(accountID) == "" {
+		accountID = credential.AccountID
+	}
+	if strings.TrimSpace(planType) == "" {
+		planType = credential.PlanType
+	}
+
+	return Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    tokenResp.AccessToken,
+		Refresh:   tokenResp.RefreshToken,
+		Expires:   time.Now().UnixMilli() + tokenResp.ExpiresIn*1000,
+		AccountID: accountID,
+		PlanType:  planType,
+	}, nil
+}

--- a/internal/auth/openai_refresh_test.go
+++ b/internal/auth/openai_refresh_test.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRefreshOpenAIOAuthCredentialSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm() error = %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "refresh_token" {
+			t.Fatalf("grant_type = %q, want refresh_token", got)
+		}
+		if got := r.Form.Get("refresh_token"); got != "old-refresh" {
+			t.Fatalf("refresh_token = %q, want old-refresh", got)
+		}
+
+		_ = json.NewEncoder(w).Encode(OpenAITokenResponse{
+			AccessToken:  jwtWithOpenAIAuthClaims("workspace-2", "pro"),
+			RefreshToken: "new-refresh",
+			ExpiresIn:    3600,
+		})
+	}))
+	defer server.Close()
+
+	originalTokenEndpoint := openAITokenEndpoint
+	openAITokenEndpoint = server.URL
+	defer func() { openAITokenEndpoint = originalTokenEndpoint }()
+
+	credential, err := refreshOpenAIOAuthCredential(Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    "old-access",
+		Refresh:   "old-refresh",
+		Expires:   time.Now().Add(-time.Minute).UnixMilli(),
+		AccountID: "workspace-1",
+		PlanType:  "plus",
+	})
+	if err != nil {
+		t.Fatalf("refreshOpenAIOAuthCredential() error = %v", err)
+	}
+	if credential.Refresh != "new-refresh" {
+		t.Fatalf("refresh token = %q, want %q", credential.Refresh, "new-refresh")
+	}
+	if credential.AccountID != "workspace-2" {
+		t.Fatalf("account id = %q, want %q", credential.AccountID, "workspace-2")
+	}
+	if credential.PlanType != "pro" {
+		t.Fatalf("plan type = %q, want %q", credential.PlanType, "pro")
+	}
+	if credential.Expires <= time.Now().UnixMilli() {
+		t.Fatal("expected refreshed expiry in the future")
+	}
+}
+
+func TestResolveOpenAIAuthRefreshesNearExpiryAndPersists(t *testing.T) {
+	manager := newTestManager(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(OpenAITokenResponse{
+			AccessToken:  jwtWithOpenAIAuthClaims("workspace-9", "pro"),
+			RefreshToken: "rotated-refresh",
+			ExpiresIn:    3600,
+		})
+	}))
+	defer server.Close()
+
+	originalTokenEndpoint := openAITokenEndpoint
+	openAITokenEndpoint = server.URL
+	defer func() { openAITokenEndpoint = originalTokenEndpoint }()
+
+	if err := manager.SaveProvider(ProviderOpenAI, Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    "old-access",
+		Refresh:   "old-refresh",
+		Expires:   time.Now().Add(30 * time.Second).UnixMilli(),
+		AccountID: "workspace-1",
+		PlanType:  "plus",
+	}); err != nil {
+		t.Fatalf("SaveProvider() error = %v", err)
+	}
+
+	resolved, err := manager.ResolveOpenAIAuth()
+	if err != nil {
+		t.Fatalf("ResolveOpenAIAuth() error = %v", err)
+	}
+	if resolved.Token == "old-access" {
+		t.Fatal("expected refreshed access token")
+	}
+	if resolved.AccountID != "workspace-9" {
+		t.Fatalf("resolved account id = %q, want %q", resolved.AccountID, "workspace-9")
+	}
+
+	authFile, err := manager.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	stored := authFile[ProviderOpenAI]
+	if stored.Refresh != "rotated-refresh" {
+		t.Fatalf("stored refresh token = %q, want %q", stored.Refresh, "rotated-refresh")
+	}
+	if stored.AccountID != "workspace-9" {
+		t.Fatalf("stored account id = %q, want %q", stored.AccountID, "workspace-9")
+	}
+}
+
+func TestResolveOpenAIAuthRefreshFailureLeavesStoredCredentialIntact(t *testing.T) {
+	manager := newTestManager(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	originalTokenEndpoint := openAITokenEndpoint
+	openAITokenEndpoint = server.URL
+	defer func() { openAITokenEndpoint = originalTokenEndpoint }()
+
+	original := Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    "old-access",
+		Refresh:   "old-refresh",
+		Expires:   time.Now().Add(-time.Minute).UnixMilli(),
+		AccountID: "workspace-1",
+		PlanType:  "plus",
+	}
+	if err := manager.SaveProvider(ProviderOpenAI, original); err != nil {
+		t.Fatalf("SaveProvider() error = %v", err)
+	}
+
+	_, err := manager.ResolveOpenAIAuth()
+	if err == nil {
+		t.Fatal("expected refresh failure")
+	}
+
+	authFile, loadErr := manager.Load()
+	if loadErr != nil {
+		t.Fatalf("Load() error = %v", loadErr)
+	}
+	stored := authFile[ProviderOpenAI]
+	if stored.Access != original.Access || stored.Refresh != original.Refresh || stored.AccountID != original.AccountID {
+		t.Fatalf("stored credential changed after failed refresh: %#v", stored)
+	}
+}
+
+func jwtWithOpenAIAuthClaims(accountID, planType string) string {
+	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := fmt.Sprintf(`{"%s":{"chatgpt_account_id":"%s","chatgpt_plan_type":"%s"}}`, jwtClaimPath, accountID, planType)
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	sigB64 := base64.RawURLEncoding.EncodeToString([]byte(`sig`))
+	return fmt.Sprintf("%s.%s.%s", headerB64, payloadB64, sigB64)
+}

--- a/internal/auth/openai_runtime.go
+++ b/internal/auth/openai_runtime.go
@@ -1,0 +1,15 @@
+package auth
+
+import "time"
+
+const (
+	OpenAICodexBaseURL          = "https://chatgpt.com/backend-api/codex"
+	OpenAIResponsesBetaHeader   = "responses=experimental"
+	OpenAIOAuthRefreshThreshold = time.Minute
+)
+
+var openAITokenEndpoint = openAITokenURL
+
+func OpenAIOriginator() string {
+	return openAIOriginator
+}

--- a/internal/auth/pkce.go
+++ b/internal/auth/pkce.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+type PkceCodes struct {
+	CodeVerifier  string
+	CodeChallenge string
+}
+
+func GeneratePKCE() (*PkceCodes, error) {
+	verifierBytes := make([]byte, 64)
+	if _, err := rand.Read(verifierBytes); err != nil {
+		return nil, err
+	}
+
+	codeVerifier := base64.RawURLEncoding.EncodeToString(verifierBytes)
+
+	digest := sha256.Sum256([]byte(codeVerifier))
+	codeChallenge := base64.RawURLEncoding.EncodeToString(digest[:])
+
+	return &PkceCodes{
+		CodeVerifier:  codeVerifier,
+		CodeChallenge: codeChallenge,
+	}, nil
+}
+
+func GenerateState() (string, error) {
+	stateBytes := make([]byte, 32)
+	if _, err := rand.Read(stateBytes); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(stateBytes), nil
+}

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -1,0 +1,183 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+func AuthPath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(homeDir) == "" {
+		homeDir = os.Getenv("HOME")
+	}
+	return filepath.Join(homeDir, ".config", "terminal-agent", "auth.json")
+}
+
+type Manager struct {
+	path string
+}
+
+func NewManager() *Manager {
+	return &Manager{path: AuthPath()}
+}
+
+func NewManagerWithPath(path string) *Manager {
+	return &Manager{path: path}
+}
+
+func (m *Manager) Path() string {
+	return m.path
+}
+
+func (m *Manager) Load() (AuthFile, error) {
+	return m.loadUnlocked()
+}
+
+func (m *Manager) loadUnlocked() (AuthFile, error) {
+	content, err := os.ReadFile(m.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return AuthFile{}, nil
+		}
+		return nil, fmt.Errorf("failed to read auth file: %w", err)
+	}
+
+	if len(content) == 0 {
+		return AuthFile{}, nil
+	}
+
+	authFile := AuthFile{}
+	if err := json.Unmarshal(content, &authFile); err != nil {
+		return nil, fmt.Errorf("failed to parse auth file: %w", err)
+	}
+
+	if authFile == nil {
+		return AuthFile{}, nil
+	}
+
+	return authFile, nil
+}
+
+func (m *Manager) Save(authFile AuthFile) error {
+	return m.withLock(func() error {
+		return m.saveUnlocked(authFile)
+	})
+}
+
+func (m *Manager) saveUnlocked(authFile AuthFile) error {
+	if authFile == nil {
+		authFile = AuthFile{}
+	}
+
+	dir := filepath.Dir(m.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create auth directory: %w", err)
+	}
+
+	content, err := json.MarshalIndent(authFile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode auth file: %w", err)
+	}
+	content = append(content, '\n')
+
+	tmpFile, err := os.CreateTemp(dir, "auth.json.*")
+	if err != nil {
+		return fmt.Errorf("failed to create auth temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	cleanup := func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+	}
+
+	if err := tmpFile.Chmod(0o600); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to set auth temp file permissions: %w", err)
+	}
+
+	if _, err := tmpFile.Write(content); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to write auth temp file: %w", err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to sync auth temp file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to close auth temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, m.path); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to replace auth file: %w", err)
+	}
+
+	if err := os.Chmod(m.path, 0o600); err != nil {
+		return fmt.Errorf("failed to set auth file permissions: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) SaveProvider(provider string, credential Credential) error {
+	return m.withLock(func() error {
+		authFile, err := m.loadUnlocked()
+		if err != nil {
+			return err
+		}
+		authFile[provider] = credential
+		return m.saveUnlocked(authFile)
+	})
+}
+
+func (m *Manager) DeleteProvider(provider string) (bool, error) {
+	deleted := false
+	err := m.withLock(func() error {
+		authFile, err := m.loadUnlocked()
+		if err != nil {
+			return err
+		}
+
+		if _, exists := authFile[provider]; !exists {
+			return nil
+		}
+
+		delete(authFile, provider)
+		deleted = true
+		return m.saveUnlocked(authFile)
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return deleted, nil
+}
+
+func (m *Manager) withLock(fn func() error) error {
+	dir := filepath.Dir(m.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create auth directory: %w", err)
+	}
+
+	lockPath := m.path + ".lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to open auth lock file: %w", err)
+	}
+	defer lockFile.Close()
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("failed to acquire auth lock: %w", err)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+
+	return fn()
+}

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -1,0 +1,48 @@
+package auth
+
+import "time"
+
+const (
+	CredentialTypeAPIKey = "api_key"
+	CredentialTypeOAuth  = "oauth"
+
+	ProviderOpenAI = "openai"
+
+	SourceEnvironment = "environment"
+	SourceStored      = "stored"
+)
+
+type Credential struct {
+	Type      string `json:"type"`
+	Key       string `json:"key,omitempty"`
+	Access    string `json:"access,omitempty"`
+	Refresh   string `json:"refresh,omitempty"`
+	Expires   int64  `json:"expires,omitempty"`
+	AccountID string `json:"account_id,omitempty"`
+	PlanType  string `json:"plan_type,omitempty"`
+}
+
+type AuthFile map[string]Credential
+
+type Status struct {
+	Provider   string
+	Type       string
+	Source     string
+	Configured bool
+	Expired    bool
+	ExpiresAt  time.Time
+	AccountID  string
+	PlanType   string
+	Path       string
+}
+
+type ResolvedAuth struct {
+	Provider  string
+	Type      string
+	Source    string
+	Token     string
+	AccountID string
+	PlanType  string
+	ExpiresAt time.Time
+	Expired   bool
+}

--- a/internal/commands/auth_cmd.go
+++ b/internal/commands/auth_cmd.go
@@ -1,0 +1,195 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/laszukdawid/terminal-agent/internal/auth"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+func NewAuthCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "auth",
+		Short:        "Manage provider authentication",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(authLoginCommand())
+	cmd.AddCommand(authStatusCommand())
+	cmd.AddCommand(authLogoutCommand())
+
+	return cmd
+}
+
+func authLoginCommand() *cobra.Command {
+	var device bool
+	var apiKeyMode bool
+	var apiKey string
+
+	cmd := &cobra.Command{
+		Use:          "login [provider]",
+		Short:        "Authenticate with a provider",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := auth.NormalizeProvider(args[0])
+			if err := auth.ValidateProvider(provider); err != nil {
+				return err
+			}
+
+			if device && apiKeyMode {
+				return fmt.Errorf("use only one auth mode flag")
+			}
+
+			if device {
+				return fmt.Errorf("OpenAI device login is not implemented yet")
+			}
+
+			if !apiKeyMode {
+				cmd.PrintErrln("Browser OAuth login is not available yet; defaulting to API key mode.")
+			}
+
+			manager := auth.NewManager()
+			key, err := resolveAPIKeyInput(apiKey)
+			if err != nil {
+				return err
+			}
+
+			if err := manager.SaveAPIKey(provider, key); err != nil {
+				return err
+			}
+
+			cmd.Printf("Stored OpenAI API key in %s\n", manager.Path())
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&device, "device", false, "Use device-code login flow")
+	cmd.Flags().BoolVar(&apiKeyMode, "api-key", false, "Store an API key instead of using OAuth")
+	cmd.Flags().StringVar(&apiKey, "key", "", "API key to store (otherwise read from OPENAI_API_KEY, terminal prompt, or stdin)")
+
+	return cmd
+}
+
+func authStatusCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "status [provider]",
+		Short:        "Show auth status for a provider",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := auth.NormalizeProvider(args[0])
+			manager := auth.NewManager()
+
+			status, err := manager.Status(provider)
+			if err != nil {
+				return err
+			}
+
+			configured := "no"
+			if status.Configured {
+				configured = "yes"
+			}
+
+			cmd.Printf("Provider: %s\n", status.Provider)
+			cmd.Printf("Configured: %s\n", configured)
+			cmd.Printf("Path: %s\n", status.Path)
+			if !status.Configured {
+				return nil
+			}
+
+			cmd.Printf("Auth type: %s\n", status.Type)
+			cmd.Printf("Source: %s\n", status.Source)
+			if status.AccountID != "" {
+				cmd.Printf("Account ID: %s\n", status.AccountID)
+			}
+			if status.PlanType != "" {
+				cmd.Printf("Plan type: %s\n", status.PlanType)
+			}
+			if !status.ExpiresAt.IsZero() {
+				cmd.Printf("Expires: %s\n", status.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z"))
+				cmd.Printf("Expired: %t\n", status.Expired)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func authLogoutCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "logout [provider]",
+		Short:        "Remove stored auth for a provider",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := auth.NormalizeProvider(args[0])
+			if err := auth.ValidateProvider(provider); err != nil {
+				return err
+			}
+
+			manager := auth.NewManager()
+			removed, err := manager.DeleteProvider(provider)
+			if err != nil {
+				return err
+			}
+
+			if !removed {
+				cmd.Printf("No stored auth found for %s\n", provider)
+				return nil
+			}
+
+			cmd.Printf("Removed stored auth for %s\n", provider)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func resolveAPIKeyInput(flagValue string) (string, error) {
+	trimmedFlagValue := strings.TrimSpace(flagValue)
+	if trimmedFlagValue != "" {
+		return trimmedFlagValue, nil
+	}
+
+	trimmedEnvValue := strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	if trimmedEnvValue != "" {
+		return trimmedEnvValue, nil
+	}
+
+	stdinFD := int(os.Stdin.Fd())
+	if term.IsTerminal(stdinFD) {
+		fmt.Fprint(os.Stderr, "OpenAI API key: ")
+		value, err := term.ReadPassword(stdinFD)
+		fmt.Fprintln(os.Stderr)
+		if err != nil {
+			return "", fmt.Errorf("failed to read API key from terminal: %w", err)
+		}
+		trimmed := strings.TrimSpace(string(value))
+		if trimmed == "" {
+			return "", fmt.Errorf("API key cannot be empty")
+		}
+		return trimmed, nil
+	}
+
+	value, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("failed to read API key from stdin: %w", err)
+	}
+
+	trimmed := strings.TrimSpace(string(value))
+	if trimmed == "" {
+		return "", fmt.Errorf("API key cannot be empty")
+	}
+	return trimmed, nil
+}

--- a/internal/commands/auth_cmd.go
+++ b/internal/commands/auth_cmd.go
@@ -48,25 +48,44 @@ func authLoginCommand() *cobra.Command {
 				return fmt.Errorf("use only one auth mode flag")
 			}
 
-			if device {
-				return fmt.Errorf("OpenAI device login is not implemented yet")
-			}
-
-			if !apiKeyMode {
-				cmd.PrintErrln("Browser OAuth login is not available yet; defaulting to API key mode.")
-			}
-
 			manager := auth.NewManager()
-			key, err := resolveAPIKeyInput(apiKey)
+
+			if device {
+				cfg := auth.DefaultBrowserLoginConfig()
+				cfg.OpenBrowser = false
+				cmd.PrintErrln("Starting device login...")
+				result, err := manager.LoginOpenAIDevice(cfg)
+				if err != nil {
+					return err
+				}
+				cmd.Printf("Successfully authenticated with OpenAI.\n")
+				cmd.Printf("Account ID: %s\n", result.AccountID)
+				cmd.Printf("Credentials stored in %s\n", manager.Path())
+				return nil
+			}
+
+			if apiKeyMode {
+				key, err := resolveAPIKeyInput(apiKey)
+				if err != nil {
+					return err
+				}
+				if err := manager.SaveAPIKey(provider, key); err != nil {
+					return err
+				}
+				cmd.Printf("Stored OpenAI API key in %s\n", manager.Path())
+				return nil
+			}
+
+			cfg := auth.DefaultBrowserLoginConfig()
+			cmd.PrintErrln("Starting browser login...")
+			result, err := manager.LoginOpenAIBrowser(cfg)
 			if err != nil {
 				return err
 			}
 
-			if err := manager.SaveAPIKey(provider, key); err != nil {
-				return err
-			}
-
-			cmd.Printf("Stored OpenAI API key in %s\n", manager.Path())
+			cmd.Printf("Successfully authenticated with OpenAI.\n")
+			cmd.Printf("Account ID: %s\n", result.AccountID)
+			cmd.Printf("Credentials stored in %s\n", manager.Path())
 			return nil
 		},
 	}

--- a/internal/commands/auth_cmd.go
+++ b/internal/commands/auth_cmd.go
@@ -77,6 +77,7 @@ func authLoginCommand() *cobra.Command {
 			}
 
 			cfg := auth.DefaultBrowserLoginConfig()
+			cfg.ManualCodeReader = os.Stdin
 			cmd.PrintErrln("Starting browser login...")
 			result, err := manager.LoginOpenAIBrowser(cfg)
 			if err != nil {

--- a/internal/connector/openai.go
+++ b/internal/connector/openai.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/laszukdawid/terminal-agent/internal/auth"
 	"github.com/laszukdawid/terminal-agent/internal/tools"
 	"github.com/laszukdawid/terminal-agent/internal/utils"
 	openai "github.com/openai/openai-go"
@@ -56,6 +57,7 @@ type OpenAIConnector struct {
 	logger  zap.Logger
 	modelID string
 	token   string
+	authErr error
 }
 
 func computePriceOpenai(modelId string, usage *openai.CompletionUsage) *LLMPrice {
@@ -97,7 +99,15 @@ func NewOpenAIConnector(modelID *string) *OpenAIConnector {
 		model := openai.ChatModelGPT4oMini
 		modelID = &model
 	}
-	token := os.Getenv("OPENAI_API_KEY")
+	manager := auth.NewManager()
+	resolvedAuth, err := manager.ResolveOpenAIAPIKeyAuth()
+	token := ""
+	var authErr error
+	if err != nil {
+		authErr = err
+	} else {
+		token = resolvedAuth.Token
+	}
 
 	// Build client options
 	clientOptions := []option.RequestOption{
@@ -117,6 +127,7 @@ func NewOpenAIConnector(modelID *string) *OpenAIConnector {
 		logger:  logger,
 		modelID: *modelID,
 		token:   token,
+		authErr: authErr,
 	}
 
 	return connector
@@ -178,6 +189,10 @@ func (oc *OpenAIConnector) streamQuery(ctx context.Context, qParams *QueryParams
 }
 
 func (oc *OpenAIConnector) Query(ctx context.Context, qParams *QueryParams) (string, error) {
+	if oc.authErr != nil {
+		return "", oc.authErr
+	}
+
 	messages := []openai.ChatCompletionMessageParamUnion{openai.SystemMessage(*qParams.SysPrompt)}
 	for _, msg := range qParams.Messages {
 		switch msg.Role {
@@ -193,7 +208,7 @@ func (oc *OpenAIConnector) Query(ctx context.Context, qParams *QueryParams) (str
 
 	oParams := openai.ChatCompletionNewParams{
 		Messages: messages,
-		Model: oc.modelID,
+		Model:    oc.modelID,
 	}
 
 	if qParams.Stream {
@@ -223,6 +238,9 @@ func (oc *OpenAIConnector) Query(ctx context.Context, qParams *QueryParams) (str
 func (oc *OpenAIConnector) QueryWithTool(ctx context.Context, qParams *QueryParams, tools map[string]tools.Tool) (LlmResponseWithTools, error) {
 	oc.logger.Sugar().Debugw("Query with tool", "model", oc.modelID)
 	response := LlmResponseWithTools{}
+	if oc.authErr != nil {
+		return response, oc.authErr
+	}
 
 	// Build client options with same configuration as NewOpenAIConnector
 	clientOptions := []option.RequestOption{

--- a/internal/connector/openai.go
+++ b/internal/connector/openai.go
@@ -56,7 +56,7 @@ type OpenAIConnector struct {
 	client  *openai.Client
 	logger  zap.Logger
 	modelID string
-	token   string
+	auth    auth.ResolvedAuth
 	authErr error
 }
 
@@ -100,24 +100,27 @@ func NewOpenAIConnector(modelID *string) *OpenAIConnector {
 		modelID = &model
 	}
 	manager := auth.NewManager()
-	resolvedAuth, err := manager.ResolveOpenAIAPIKeyAuth()
-	token := ""
+	resolvedAuth, err := manager.ResolveOpenAIAuth()
 	var authErr error
+	clientOptions := []option.RequestOption{}
 	if err != nil {
 		authErr = err
 	} else {
-		token = resolvedAuth.Token
-	}
-
-	// Build client options
-	clientOptions := []option.RequestOption{
-		option.WithAPIKey(token),
-	}
-
-	// Check for custom base URL
-	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
-		clientOptions = append(clientOptions, option.WithBaseURL(baseURL))
-		logger.Debug("Using custom OpenAI base URL", zap.String("baseURL", baseURL))
+		clientOptions = append(clientOptions, option.WithAPIKey(resolvedAuth.Token))
+		switch resolvedAuth.Type {
+		case auth.CredentialTypeOAuth:
+			clientOptions = append(clientOptions,
+				option.WithBaseURL(auth.OpenAICodexBaseURL),
+				option.WithHeader("ChatGPT-Account-ID", resolvedAuth.AccountID),
+				option.WithHeader("originator", auth.OpenAIOriginator()),
+				option.WithHeader("OpenAI-Beta", auth.OpenAIResponsesBetaHeader),
+			)
+		default:
+			if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
+				clientOptions = append(clientOptions, option.WithBaseURL(baseURL))
+				logger.Debug("Using custom OpenAI base URL", zap.String("baseURL", baseURL))
+			}
+		}
 	}
 
 	client := openai.NewClient(clientOptions...)
@@ -126,7 +129,7 @@ func NewOpenAIConnector(modelID *string) *OpenAIConnector {
 		client:  &client,
 		logger:  logger,
 		modelID: *modelID,
-		token:   token,
+		auth:    resolvedAuth,
 		authErr: authErr,
 	}
 
@@ -192,6 +195,9 @@ func (oc *OpenAIConnector) Query(ctx context.Context, qParams *QueryParams) (str
 	if oc.authErr != nil {
 		return "", oc.authErr
 	}
+	if oc.auth.Type == auth.CredentialTypeOAuth {
+		return oc.queryOAuth(ctx, qParams)
+	}
 
 	messages := []openai.ChatCompletionMessageParamUnion{openai.SystemMessage(*qParams.SysPrompt)}
 	for _, msg := range qParams.Messages {
@@ -241,18 +247,9 @@ func (oc *OpenAIConnector) QueryWithTool(ctx context.Context, qParams *QueryPara
 	if oc.authErr != nil {
 		return response, oc.authErr
 	}
-
-	// Build client options with same configuration as NewOpenAIConnector
-	clientOptions := []option.RequestOption{
-		option.WithAPIKey(oc.token),
+	if oc.auth.Type == auth.CredentialTypeOAuth {
+		return oc.queryWithToolOAuth(ctx, qParams, tools)
 	}
-
-	// Check for custom base URL
-	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
-		clientOptions = append(clientOptions, option.WithBaseURL(baseURL))
-	}
-
-	client := openai.NewClient(clientOptions...)
 
 	oParams := openai.ChatCompletionNewParams{
 		Messages: []openai.ChatCompletionMessageParamUnion{
@@ -263,7 +260,7 @@ func (oc *OpenAIConnector) QueryWithTool(ctx context.Context, qParams *QueryPara
 		Model: oc.modelID,
 	}
 
-	completion, err := client.Chat.Completions.New(ctx, oParams)
+	completion, err := oc.client.Chat.Completions.New(ctx, oParams)
 	if err != nil {
 		return response, err
 	}

--- a/internal/connector/openai_oauth.go
+++ b/internal/connector/openai_oauth.go
@@ -1,0 +1,164 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared"
+	"go.uber.org/zap"
+)
+
+func convertToolsToResponses(execTools map[string]tools.Tool) []responses.ToolUnionParam {
+	toolSpecs := make([]responses.ToolUnionParam, 0, len(execTools))
+	for _, tool := range execTools {
+		toolSpecs = append(toolSpecs, responses.ToolParamOfFunction(tool.Name(), tool.InputSchema(), false))
+	}
+	return toolSpecs
+}
+
+func roleToResponses(role string) responses.EasyInputMessageRole {
+	switch role {
+	case "assistant":
+		return responses.EasyInputMessageRoleAssistant
+	default:
+		return responses.EasyInputMessageRoleUser
+	}
+}
+
+func buildResponsesParams(modelID string, qParams *QueryParams) responses.ResponseNewParams {
+	input := responses.ResponseInputParam{}
+	for _, msg := range qParams.Messages {
+		input = append(input, responses.ResponseInputItemParamOfMessage(msg.Content, roleToResponses(msg.Role)))
+	}
+	if qParams.UserPrompt != nil {
+		input = append(input, responses.ResponseInputItemParamOfMessage(*qParams.UserPrompt, responses.EasyInputMessageRoleUser))
+	}
+
+	params := responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: input,
+		},
+		Model:        shared.ResponsesModel(modelID),
+		Instructions: openai.String(*qParams.SysPrompt),
+	}
+	if qParams.MaxTokens > 0 {
+		params.MaxOutputTokens = openai.Int(int64(qParams.MaxTokens))
+	}
+	return params
+}
+
+func (oc *OpenAIConnector) streamOAuthQuery(ctx context.Context, qParams *QueryParams, params responses.ResponseNewParams) (*string, error) {
+	var mdRenderer *MarkdownStreamRenderer
+	if qParams.OnStream == nil {
+		renderer, err := NewMarkdownStreamRenderer()
+		if err != nil {
+			oc.logger.Warn("Failed to create markdown renderer, falling back to plain text", zap.Error(err))
+		} else {
+			mdRenderer = renderer
+		}
+	}
+
+	stream := oc.client.Responses.NewStreaming(ctx, params)
+	var streamedText strings.Builder
+	var completedText string
+
+	for stream.Next() {
+		event := stream.Current()
+		switch event.Type {
+		case "response.output_text.delta":
+			delta := event.AsResponseOutputTextDelta().Delta
+			streamedText.WriteString(delta)
+			if qParams.OnStream != nil {
+				if err := qParams.OnStream(delta); err != nil {
+					return nil, err
+				}
+			} else if mdRenderer != nil {
+				mdRenderer.ProcessChunk(delta)
+			} else {
+				print(delta)
+			}
+		case "response.completed":
+			completedText = event.AsResponseCompleted().Response.OutputText()
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		return nil, err
+	}
+
+	if mdRenderer != nil {
+		mdRenderer.Flush()
+	}
+
+	if completedText != "" {
+		return &completedText, nil
+	}
+
+	text := streamedText.String()
+	return &text, nil
+}
+
+func (oc *OpenAIConnector) queryOAuth(ctx context.Context, qParams *QueryParams) (string, error) {
+	params := buildResponsesParams(oc.modelID, qParams)
+	if qParams.Stream {
+		result, err := oc.streamOAuthQuery(ctx, qParams, params)
+		if err != nil {
+			return "", err
+		}
+		if result == nil {
+			return "", nil
+		}
+		return *result, nil
+	}
+
+	response, err := oc.client.Responses.New(ctx, params)
+	if err != nil {
+		return "", err
+	}
+
+	return response.OutputText(), nil
+}
+
+func (oc *OpenAIConnector) queryWithToolOAuth(ctx context.Context, qParams *QueryParams, tools map[string]tools.Tool) (LlmResponseWithTools, error) {
+	response := LlmResponseWithTools{}
+	params := buildResponsesParams(oc.modelID, qParams)
+	params.Tools = convertToolsToResponses(tools)
+	params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+		OfToolChoiceMode: openai.Opt(responses.ToolChoiceOptionsAuto),
+	}
+	params.ParallelToolCalls = openai.Bool(true)
+
+	result, err := oc.client.Responses.New(ctx, params)
+	if err != nil {
+		return response, err
+	}
+
+	response.Response = result.OutputText()
+	for _, item := range result.Output {
+		if item.Type != "function_call" {
+			continue
+		}
+		if item.Name == "" {
+			return response, fmt.Errorf("tool call name is empty")
+		}
+		if item.Arguments == "" {
+			return response, fmt.Errorf("tool call arguments are empty")
+		}
+
+		var args map[string]any
+		if err := json.Unmarshal([]byte(item.Arguments), &args); err != nil {
+			return response, fmt.Errorf("failed to parse tool call arguments: %w", err)
+		}
+
+		response.ToolUse = true
+		response.ToolName = item.Name
+		response.ToolInput = args
+	}
+
+	return response, nil
+}

--- a/internal/connector/openai_oauth_test.go
+++ b/internal/connector/openai_oauth_test.go
@@ -1,0 +1,73 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+	"github.com/openai/openai-go/responses"
+)
+
+type stubTool struct{}
+
+func (stubTool) RunSchema(input map[string]any) (string, error) { return "", nil }
+func (stubTool) Run(input *string) (string, error)              { return "", nil }
+func (stubTool) Name() string                                   { return "search_code" }
+func (stubTool) Description() string                            { return "Search code" }
+func (stubTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{"type": "string"},
+		},
+	}
+}
+func (stubTool) HelpText() string { return "" }
+
+func TestBuildResponsesParamsIncludesHistoryAndPrompt(t *testing.T) {
+	sysPrompt := "You are helpful"
+	userPrompt := "latest question"
+	params := buildResponsesParams("gpt-4o-mini", &QueryParams{
+		SysPrompt:  &sysPrompt,
+		UserPrompt: &userPrompt,
+		Messages: []Message{
+			{Role: "user", Content: "old user"},
+			{Role: "assistant", Content: "old answer"},
+		},
+		MaxTokens: 321,
+	})
+
+	if params.Instructions.Value != sysPrompt {
+		t.Fatalf("instructions = %q, want %q", params.Instructions.Value, sysPrompt)
+	}
+	if params.Model != "gpt-4o-mini" {
+		t.Fatalf("model = %q, want %q", params.Model, "gpt-4o-mini")
+	}
+	if params.MaxOutputTokens.Value != 321 {
+		t.Fatalf("max output tokens = %d, want %d", params.MaxOutputTokens.Value, 321)
+	}
+	if len(params.Input.OfInputItemList) != 3 {
+		t.Fatalf("input items = %d, want 3", len(params.Input.OfInputItemList))
+	}
+	if params.Input.OfInputItemList[0].OfMessage == nil || params.Input.OfInputItemList[0].OfMessage.Role != responses.EasyInputMessageRoleUser {
+		t.Fatal("expected first input item to be a user message")
+	}
+	if params.Input.OfInputItemList[1].OfMessage == nil || params.Input.OfInputItemList[1].OfMessage.Role != responses.EasyInputMessageRoleAssistant {
+		t.Fatal("expected second input item to be an assistant message")
+	}
+}
+
+func TestConvertToolsToResponses(t *testing.T) {
+	toolSpecs := convertToolsToResponses(map[string]tools.Tool{
+		"search_code": stubTool{},
+	})
+
+	if len(toolSpecs) != 1 {
+		t.Fatalf("tool specs = %d, want 1", len(toolSpecs))
+	}
+	if toolSpecs[0].OfFunction == nil {
+		t.Fatal("expected function tool spec")
+	}
+	if toolSpecs[0].OfFunction.Name != "search_code" {
+		t.Fatalf("tool name = %q, want %q", toolSpecs[0].OfFunction.Name, "search_code")
+	}
+}

--- a/internal/gui/settings_validation.go
+++ b/internal/gui/settings_validation.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/laszukdawid/terminal-agent/internal/auth"
 	"github.com/laszukdawid/terminal-agent/internal/connector"
 )
 
@@ -35,8 +36,12 @@ func validateProviderModel(provider, model string) error {
 func providerSetupHint(provider string) string {
 	switch provider {
 	case connector.OpenaiProvider:
+		status, err := auth.NewManager().Status(provider)
+		if err == nil && status.Configured {
+			return ""
+		}
 		if os.Getenv("OPENAI_API_KEY") == "" {
-			return "OpenAI requires OPENAI_API_KEY to be set."
+			return "OpenAI requires OPENAI_API_KEY or 'agent auth login openai'."
 		}
 	case connector.AnthropicProvider:
 		if os.Getenv("ANTHROPIC_API_KEY") == "" {
@@ -79,6 +84,10 @@ func explainRuntimeError(provider string, err error) string {
 	case strings.Contains(lower, "api key"), strings.Contains(lower, "authenticate"), strings.Contains(lower, "authentication"):
 		if hint != "" {
 			return hint
+		}
+	case strings.Contains(lower, "oauth login has expired"), strings.Contains(lower, "agent auth login openai' again"):
+		if provider == connector.OpenaiProvider {
+			return "Stored OpenAI login has expired. Run 'agent auth login openai' again or set OPENAI_API_KEY."
 		}
 	case strings.Contains(lower, "status code: 401"), strings.Contains(lower, "status code 401"):
 		if hint != "" {


### PR DESCRIPTION
## Summary
- add a dedicated OpenAI auth subsystem with stored API key and OAuth credential support
- implement browser and device login flows plus automatic OAuth refresh
- route OpenAI API-key auth through the existing Chat Completions path and OAuth auth through the Codex Responses path
- update auth docs and GUI/provider setup hints for the new OpenAI auth flows

## Testing
- go test ./...

## Notes
- excludes the in-worktree plan/status files from this PR as requested