### PR TITLE
feat: add Mistral provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,30 @@ agent auth status openai
 
 See `agent auth --help` for more authentication options.
 
+### Mistral
+
+Mistral offers a range of models from the lightweight Ministral to the powerful Large model, all accessible through a straightforward API.
+
+To use directly:
+1. Create an account at [Mistral AI](https://console.mistral.ai/)
+2. Generate an API key from the [API Keys page](https://console.mistral.ai/api-keys/)
+3. Set the key as an environment variable:
+   ```sh
+   export MISTRAL_API_KEY=your_api_key_here
+   ```
+
+Setting `mistral` provider with `mistral-small-latest` model:
+
+```sh
+$ agent config set provider mistral
+$ agent config set model mistral-small-latest
+```
+
+For a custom or self-hosted endpoint, set `MISTRAL_BASE_URL`:
+```sh
+export MISTRAL_BASE_URL=https://your-endpoint.com
+```
+
 ### Ollama
 
 Ollama allows you to run large language models locally on your machine. This provides privacy, offline capability, and no API costs. To use Ollama with the terminal agent, you first need to install and run Ollama on your system.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,7 @@ Stored credentials are managed with the `agent auth` command and take effect aut
 | OpenAI | `OPENAI_API_KEY` | supported | API key or stored credential for OpenAI services |
 | Anthropic | `ANTHROPIC_API_KEY` | — | API key for Anthropic Claude models |
 | Google | `GOOGLE_API_KEY` | — | API key for Google AI (Gemini) |
+| Mistral | `MISTRAL_API_KEY` | — | API key for Mistral AI models |
 | AWS Bedrock | AWS credentials | — | Standard AWS credential configuration |
 | Llama.cpp | `YZMA_LIB` | — | Path to the directory containing the local llama.cpp shared libraries used by the `llama` provider |
 | Ollama | `OLLAMA_HOST` | — | Host URL for Ollama server |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -240,11 +240,45 @@ agent config set model anthropic.claude-3-haiku-20240307-v1:0
 - Tool usage capability for the `task` command
 - Supports streaming output with the `--stream` flag
 
+### Mistral
+
+**Setup:**
+1. Create an account at [Mistral AI](https://console.mistral.ai/)
+2. Generate an API key from the [Console](https://console.mistral.ai/api-keys/)
+3. Set the key as an environment variable:
+   ```sh
+   export MISTRAL_API_KEY=your_api_key_here
+   ```
+
+**Configuration:**
+```sh
+agent config set provider mistral
+agent config set model mistral-small-latest
+```
+
+**Custom API Endpoints:**
+If you're using a Mistral-compatible API endpoint, you can set a custom base URL:
+```sh
+export MISTRAL_BASE_URL=https://your-custom-endpoint.com
+```
+
+**Recommended Models:**
+- `mistral-small-latest` - Good balance of capability and cost
+- `mistral-large-latest` - Higher capability, higher cost
+- `mistral-medium-latest` - Medium capability
+- `codestral-latest` - Optimized for code generation
+- `ministral-8b-latest` - Smaller, faster model
+
+**Special Features:**
+- Tool usage capability for the `task` command
+- Supports streaming output with the `--stream` flag
+- Compatible with Mistral-compatible endpoints via `MISTRAL_BASE_URL`
+
 ## Performance Considerations
 
 Different providers excel at different tasks:
 
 - **Complex reasoning**: Anthropic Claude models (direct or via Bedrock)
-- **Speed and cost-efficiency**: OpenAI's GPT-3.5, Google's Gemini Flash models
-- **Creative tasks**: OpenAI's GPT-4 series, Anthropic Claude Opus
+- **Speed and cost-efficiency**: OpenAI's GPT-3.5, Google's Gemini Flash models, Mistral Small models
+- **Creative tasks**: OpenAI's GPT-4 series, Anthropic Claude Opus, Mistral Large models
 - **Open-source options**: Llama models via the local `llama` provider, Ollama, or Bedrock-hosted Llama models

--- a/internal/commands/config_cmd.go
+++ b/internal/commands/config_cmd.go
@@ -15,6 +15,7 @@ var supportedProviders = []string{
 	connector.BedrockProvider,
 	connector.GoogleProvider,
 	connector.LlamaProvider,
+	connector.MistralProvider,
 	connector.OllamaProvider,
 	connector.OpenaiProvider,
 }

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -79,6 +79,7 @@ func NewDefaultConfig() *config {
 			"bedrock":   "anthropic.claude-3-haiku-20240307-v1:0",
 			"google":    "gemini-2.0-flash-lite",
 			"llama":     "llama3.2",
+			"mistral":   "mistral-small-latest",
 			"openai":    "gpt-4o-mini",
 			"ollama":    "llama3.2",
 		},

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -73,6 +73,7 @@ func TestLoadConfig(t *testing.T) {
 		assert.Equal(t, "claude-3-5-haiku-latest", config.Providers["anthropic"])
 		assert.Equal(t, "anthropic.claude-3-haiku-20240307-v1:0", config.Providers["bedrock"])
 		assert.Equal(t, "llama3.2", config.Providers["llama"])
+		assert.Equal(t, "mistral-small-latest", config.Providers["mistral"])
 		assert.Equal(t, "gpt-4o-mini", config.Providers["openai"])
 		assert.Equal(t, "gemini-2.0-flash-lite", config.Providers["google"])
 		assert.Equal(t, "llama3.2", config.Providers["ollama"])

--- a/internal/connector/main.go
+++ b/internal/connector/main.go
@@ -22,6 +22,8 @@ func NewConnector(provider string, modelID string, cfg config.Config) (LLMConnec
 		connector = NewLlamaConnector(&modelID, cfg)
 	case OllamaProvider:
 		connector = NewOllamaConnector(&modelID)
+	case MistralProvider:
+		connector = NewMistralConnector(&modelID)
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", provider)
 	}

--- a/internal/connector/main_test.go
+++ b/internal/connector/main_test.go
@@ -21,3 +21,12 @@ func TestNewConnectorUsesProviderDefaultModelWhenModelIDEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.IsType(t, &OpenAIConnector{}, conn)
 }
+
+func TestNewConnectorCreatesMistralConnector(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+
+	conn, err := NewConnector(MistralProvider, "mistral-large-latest", nil)
+
+	require.NoError(t, err)
+	assert.IsType(t, &MistralConnector{}, conn)
+}

--- a/internal/connector/mistral.go
+++ b/internal/connector/mistral.go
@@ -1,0 +1,434 @@
+package connector
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+	"github.com/laszukdawid/terminal-agent/internal/utils"
+	"go.uber.org/zap"
+)
+
+const (
+	MistralProvider     = "mistral"
+	DefaultMistralModel = "mistral-small-latest"
+
+	DefaultMistralBaseURL = "https://api.mistral.ai"
+)
+
+type MistralRequest struct {
+	Model             string          `json:"model"`
+	Messages          []MistralMessage `json:"messages"`
+	Stream            bool            `json:"stream,omitempty"`
+	MaxTokens         *int            `json:"max_tokens,omitempty"`
+	Tools             []MistralTool   `json:"tools,omitempty"`
+	ToolChoice        string          `json:"tool_choice,omitempty"`
+	ParallelToolCalls *bool           `json:"parallel_tool_calls,omitempty"`
+}
+
+type MistralMessage struct {
+	Role      string            `json:"role"`
+	Content   string            `json:"content,omitempty"`
+	ToolCalls []MistralToolCall `json:"tool_calls,omitempty"`
+}
+
+type MistralTool struct {
+	Type     string              `json:"type"`
+	Function MistralToolFunction `json:"function"`
+}
+
+type MistralToolFunction struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+}
+
+type MistralToolCall struct {
+	ID       string                 `json:"id"`
+	Type     string                 `json:"type"`
+	Function MistralToolCallFunction `json:"function"`
+}
+
+type MistralToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type MistralResponse struct {
+	ID      string          `json:"id"`
+	Model   string          `json:"model"`
+	Choices []MistralChoice `json:"choices"`
+	Usage   *MistralUsage   `json:"usage,omitempty"`
+}
+
+type MistralChoice struct {
+	Index        int            `json:"index"`
+	Message      MistralMessage `json:"message,omitempty"`
+	Delta        *MistralDelta  `json:"delta,omitempty"`
+	FinishReason *string        `json:"finish_reason,omitempty"`
+}
+
+type MistralDelta struct {
+	Content   string            `json:"content,omitempty"`
+	ToolCalls []MistralToolCall `json:"tool_calls,omitempty"`
+}
+
+type MistralUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type MistralErrorResponse struct {
+	Object  string `json:"object"`
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code"`
+}
+
+type MistralConnector struct {
+	apiKey     string
+	baseURL    string
+	modelID    string
+	httpClient *http.Client
+	logger     zap.Logger
+}
+
+func NewMistralConnector(modelID *string) *MistralConnector {
+	logger := *utils.GetLogger()
+	logger.Debug("NewMistralConnector")
+
+	if modelID == nil || *modelID == "" {
+		model := DefaultMistralModel
+		modelID = &model
+	}
+
+	apiKey := os.Getenv("MISTRAL_API_KEY")
+	if apiKey == "" {
+		logger.Error("MISTRAL_API_KEY is required to use Mistral models")
+		return nil
+	}
+
+	baseURL := os.Getenv("MISTRAL_BASE_URL")
+	if baseURL == "" {
+		baseURL = DefaultMistralBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	connector := &MistralConnector{
+		apiKey:  apiKey,
+		baseURL: baseURL,
+		modelID: *modelID,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+		logger: logger,
+	}
+
+	return connector
+}
+
+func convertToolsToMistral(execTools map[string]tools.Tool) []MistralTool {
+	var toolSpecs []MistralTool
+	for _, tool := range execTools {
+		toolSpec := MistralTool{
+			Type: "function",
+			Function: MistralToolFunction{
+				Name:        tool.Name(),
+				Description: tool.Description(),
+				Parameters:  tool.InputSchema(),
+			},
+		}
+		toolSpecs = append(toolSpecs, toolSpec)
+	}
+	return toolSpecs
+}
+
+func (mc *MistralConnector) buildMessages(qParams *QueryParams) []MistralMessage {
+	messages := []MistralMessage{}
+
+	if qParams.SysPrompt != nil && *qParams.SysPrompt != "" {
+		messages = append(messages, MistralMessage{
+			Role:    "system",
+			Content: *qParams.SysPrompt,
+		})
+	}
+
+	for _, msg := range qParams.Messages {
+		messages = append(messages, MistralMessage{
+			Role:    msg.Role,
+			Content: msg.Content,
+		})
+	}
+
+	if qParams.UserPrompt != nil && *qParams.UserPrompt != "" {
+		messages = append(messages, MistralMessage{
+			Role:    "user",
+			Content: *qParams.UserPrompt,
+		})
+	}
+
+	return messages
+}
+
+func (mc *MistralConnector) Query(ctx context.Context, params *QueryParams) (string, error) {
+	mc.logger.Sugar().Debugw("Query", "model", mc.modelID)
+
+	messages := mc.buildMessages(params)
+
+	request := MistralRequest{
+		Model:    mc.modelID,
+		Messages: messages,
+		Stream:   params.Stream,
+	}
+
+	if params.MaxTokens > 0 {
+		maxTokens := params.MaxTokens
+		request.MaxTokens = &maxTokens
+	}
+
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := mc.baseURL + "/v1/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+mc.apiKey)
+
+	resp, err := mc.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", mc.parseErrorResponse(resp)
+	}
+
+	if params.Stream {
+		return mc.handleStreamingResponse(resp, params.OnStream)
+	}
+
+	return mc.parseCompletionResponse(resp)
+}
+
+func (mc *MistralConnector) QueryWithTool(ctx context.Context, params *QueryParams, execTools map[string]tools.Tool) (LlmResponseWithTools, error) {
+	mc.logger.Sugar().Debugw("Query with tool", "model", mc.modelID)
+	response := LlmResponseWithTools{}
+
+	messages := []MistralMessage{}
+
+	if params.SysPrompt != nil && *params.SysPrompt != "" {
+		messages = append(messages, MistralMessage{
+			Role:    "system",
+			Content: *params.SysPrompt,
+		})
+	}
+
+	if params.UserPrompt != nil && *params.UserPrompt != "" {
+		messages = append(messages, MistralMessage{
+			Role:    "user",
+			Content: *params.UserPrompt,
+		})
+	}
+
+	mistralTools := convertToolsToMistral(execTools)
+	parallelToolCalls := false
+
+	request := MistralRequest{
+		Model:             mc.modelID,
+		Messages:          messages,
+		Tools:             mistralTools,
+		ToolChoice:        "auto",
+		ParallelToolCalls: &parallelToolCalls,
+	}
+
+	if params.MaxTokens > 0 {
+		maxTokens := params.MaxTokens
+		request.MaxTokens = &maxTokens
+	}
+
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		return response, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := mc.baseURL + "/v1/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return response, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+mc.apiKey)
+
+	mc.logger.Sugar().Debugw("Sending message to Mistral", "userPrompt", *params.UserPrompt, "tools", len(mistralTools))
+
+	resp, err := mc.httpClient.Do(req)
+	if err != nil {
+		return response, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return response, mc.parseErrorResponse(resp)
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return response, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var mistralResp MistralResponse
+	if err := json.Unmarshal(responseBody, &mistralResp); err != nil {
+		return response, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	mc.logger.Sugar().Debugw("Received response from Mistral", "response", mistralResp)
+
+	if len(mistralResp.Choices) == 0 {
+		return response, fmt.Errorf("no response from Mistral")
+	}
+
+	choice := mistralResp.Choices[0]
+	if choice.Message.Content != "" {
+		response.Response = choice.Message.Content
+	}
+
+	if len(choice.Message.ToolCalls) > 0 {
+		toolCall := choice.Message.ToolCalls[0]
+
+		if toolCall.Function.Name == "" {
+			return response, fmt.Errorf("tool call name is empty")
+		}
+		if toolCall.Function.Arguments == "" {
+			return response, fmt.Errorf("tool call arguments are empty")
+		}
+
+		var args map[string]any
+		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
+			return response, fmt.Errorf("failed to unmarshal tool call arguments: %w", err)
+		}
+
+		response.ToolUse = true
+		response.ToolName = toolCall.Function.Name
+		response.ToolInput = args
+	}
+
+	return response, nil
+}
+
+func (mc *MistralConnector) SupportsNativeToolCalling() bool {
+	return true
+}
+
+func (mc *MistralConnector) parseCompletionResponse(resp *http.Response) (string, error) {
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var mistralResp MistralResponse
+	if err := json.Unmarshal(responseBody, &mistralResp); err != nil {
+		return "", fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if len(mistralResp.Choices) == 0 {
+		return "", fmt.Errorf("no response from Mistral")
+	}
+
+	return mistralResp.Choices[0].Message.Content, nil
+}
+
+func (mc *MistralConnector) handleStreamingResponse(resp *http.Response, onStream func(string) error) (string, error) {
+	var mdRenderer *MarkdownStreamRenderer
+	if onStream == nil {
+		renderer, err := NewMarkdownStreamRenderer()
+		if err != nil {
+			mc.logger.Warn("Failed to create markdown renderer, falling back to plain text", zap.Error(err))
+		} else {
+			mdRenderer = renderer
+		}
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	var fullResponse string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if line == "" {
+			continue
+		}
+
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk MistralResponse
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+
+		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
+			content := chunk.Choices[0].Delta.Content
+			if content != "" {
+				fullResponse += content
+
+				if onStream != nil {
+					if err := onStream(content); err != nil {
+						return "", err
+					}
+				} else if mdRenderer != nil {
+					mdRenderer.ProcessChunk(content)
+				} else {
+					fmt.Print(content)
+				}
+			}
+		}
+	}
+
+	if mdRenderer != nil {
+		mdRenderer.Flush()
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error reading stream: %w", err)
+	}
+
+	return fullResponse, nil
+}
+
+func (mc *MistralConnector) parseErrorResponse(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+
+	var errResp MistralErrorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Message != "" {
+		return fmt.Errorf("mistral API error (status %d): %s", resp.StatusCode, errResp.Message)
+	}
+
+	bodyStr := string(body)
+	if bodyStr == "" {
+		bodyStr = http.StatusText(resp.StatusCode)
+	}
+
+	return fmt.Errorf("mistral API returned status %d: %s", resp.StatusCode, bodyStr)
+}

--- a/internal/connector/mistral_test.go
+++ b/internal/connector/mistral_test.go
@@ -1,0 +1,484 @@
+package connector
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMistralConnector(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	modelID := "mistral-large-latest"
+
+	connector := NewMistralConnector(&modelID)
+
+	if connector == nil {
+		t.Fatal("Expected connector to be created, got nil")
+	}
+
+	if connector.modelID != modelID {
+		t.Errorf("Expected modelID to be %s, got %s", modelID, connector.modelID)
+	}
+
+	if connector.apiKey != "test-key" {
+		t.Errorf("Expected apiKey to be test-key, got %s", connector.apiKey)
+	}
+
+	if connector.baseURL != DefaultMistralBaseURL {
+		t.Errorf("Expected baseURL to be %s, got %s", DefaultMistralBaseURL, connector.baseURL)
+	}
+}
+
+func TestNewMistralConnectorNoKey(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "")
+	modelID := "mistral-large-latest"
+
+	connector := NewMistralConnector(&modelID)
+
+	assert.Nil(t, connector, "Expected connector to be nil when MISTRAL_API_KEY is not set")
+}
+
+func TestNewMistralConnectorNoModelID(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	var modelID *string
+
+	connector := NewMistralConnector(modelID)
+
+	if connector == nil {
+		t.Fatal("Expected connector to be created, got nil")
+	}
+
+	if connector.modelID != DefaultMistralModel {
+		t.Errorf("Expected modelID to be %s, got %s", DefaultMistralModel, connector.modelID)
+	}
+}
+
+func TestNewMistralConnectorCustomBaseURL(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("MISTRAL_BASE_URL", "https://mistral.example.com")
+	modelID := "mistral-large-latest"
+
+	connector := NewMistralConnector(&modelID)
+
+	if connector == nil {
+		t.Fatal("Expected connector to be created, got nil")
+	}
+
+	if connector.baseURL != "https://mistral.example.com" {
+		t.Errorf("Expected baseURL to be https://mistral.example.com, got %s", connector.baseURL)
+	}
+}
+
+func TestNewMistralConnectorCustomBaseURLTrailingSlash(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("MISTRAL_BASE_URL", "https://mistral.example.com/")
+	modelID := "mistral-large-latest"
+
+	connector := NewMistralConnector(&modelID)
+
+	if connector == nil {
+		t.Fatal("Expected connector to be created, got nil")
+	}
+
+	if connector.baseURL != "https://mistral.example.com" {
+		t.Errorf("Expected baseURL to have trailing slash trimmed, got %s", connector.baseURL)
+	}
+}
+
+func TestConvertToolsToMistral(t *testing.T) {
+	execTools := map[string]tools.Tool{
+		"unix": tools.NewUnixTool(nil),
+	}
+
+	toolSpecs := convertToolsToMistral(execTools)
+
+	if len(toolSpecs) != 1 {
+		t.Fatalf("Expected 1 tool spec, got %d", len(toolSpecs))
+	}
+
+	toolSpec := toolSpecs[0]
+	expectedTool := execTools["unix"]
+
+	assert.Equal(t, "function", toolSpec.Type, "Expected tool type to be function")
+	assert.Equal(t, expectedTool.Name(), toolSpec.Function.Name, "Expected tool name to be %s, got %s", expectedTool.Name(), toolSpec.Function.Name)
+	assert.Equal(t, expectedTool.Description(), toolSpec.Function.Description, "Expected tool description to be %s, got %s", expectedTool.Description(), toolSpec.Function.Description)
+	assert.NotNil(t, toolSpec.Function.Parameters, "Expected parameters to be non-nil")
+}
+
+func TestMistralBuildMessages(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	modelID := "mistral-small-latest"
+	mc := NewMistralConnector(&modelID)
+	if mc == nil {
+		t.Fatal("Expected connector to be created")
+	}
+
+	sysPrompt := "You are helpful."
+	userPrompt := "Hello"
+
+	params := &QueryParams{
+		SysPrompt:  &sysPrompt,
+		UserPrompt: &userPrompt,
+		Messages: []Message{
+			{Role: "user", Content: "Previous message"},
+			{Role: "assistant", Content: "Previous response"},
+		},
+	}
+
+	messages := mc.buildMessages(params)
+
+	assert.Equal(t, 4, len(messages))
+	assert.Equal(t, "system", messages[0].Role)
+	assert.Equal(t, sysPrompt, messages[0].Content)
+	assert.Equal(t, "user", messages[1].Role)
+	assert.Equal(t, "Previous message", messages[1].Content)
+	assert.Equal(t, "assistant", messages[2].Role)
+	assert.Equal(t, "Previous response", messages[2].Content)
+	assert.Equal(t, "user", messages[3].Role)
+	assert.Equal(t, userPrompt, messages[3].Content)
+}
+
+func TestMistralBuildMessagesEmptySystem(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	modelID := "mistral-small-latest"
+	mc := NewMistralConnector(&modelID)
+	if mc == nil {
+		t.Fatal("Expected connector to be created")
+	}
+
+	sysPrompt := ""
+	userPrompt := "Hello"
+
+	params := &QueryParams{
+		SysPrompt:  &sysPrompt,
+		UserPrompt: &userPrompt,
+	}
+
+	messages := mc.buildMessages(params)
+
+	assert.Equal(t, 1, len(messages))
+	assert.Equal(t, "user", messages[0].Role)
+	assert.Equal(t, userPrompt, messages[0].Content)
+}
+
+func TestMistralSSEParse(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	modelID := "mistral-small-latest"
+	mc := NewMistralConnector(&modelID)
+	if mc == nil {
+		t.Fatal("Expected connector to be created")
+	}
+
+	t.Run("normal streaming response", func(t *testing.T) {
+		sseBody := `data: {"id":"1","choices":[{"delta":{"content":"Hello"}}]}
+
+data: {"id":"2","choices":[{"delta":{"content":" world"}}]}
+
+data: {"id":"3","choices":[{"delta":{"content":"!"}}]}
+
+data: [DONE]
+`
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(sseBody))
+		}))
+		defer server.Close()
+
+		// Override baseURL temporarily - we need to test the streaming handler directly
+		// by constructing a request to the test server
+		req, err := http.NewRequest("POST", server.URL+"/v1/chat/completions", nil)
+		assert.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer test-key")
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		var chunks []string
+		onStream := func(chunk string) error {
+			chunks = append(chunks, chunk)
+			return nil
+		}
+
+		result, err := mc.handleStreamingResponse(resp, onStream)
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello world!", result)
+		assert.Equal(t, []string{"Hello", " world", "!"}, chunks)
+	})
+
+	t.Run("stream with empty lines and other SSE fields", func(t *testing.T) {
+		sseBody := `event: message
+data: {"id":"1","choices":[{"delta":{"content":"A"}}]}
+
+id: 1
+data: {"id":"2","choices":[{"delta":{"content":"B"}}]}
+
+data: [DONE]
+`
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(sseBody))
+		}))
+		defer server.Close()
+
+		req, err := http.NewRequest("POST", server.URL+"/v1/chat/completions", nil)
+		assert.NoError(t, err)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		result, err := mc.handleStreamingResponse(resp, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "AB", result)
+	})
+
+	t.Run("stream with no DONE signal", func(t *testing.T) {
+		sseBody := `data: {"id":"1","choices":[{"delta":{"content":"partial"}}]}`
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.(http.Flusher).Flush()
+			w.Write([]byte(sseBody))
+		}))
+		defer server.Close()
+
+		req, err := http.NewRequest("POST", server.URL+"/v1/chat/completions", nil)
+		assert.NoError(t, err)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		result, err := mc.handleStreamingResponse(resp, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "partial", result)
+	})
+}
+
+func TestMistralToolCallResponseParse(t *testing.T) {
+	responseJSON := `{
+		"id": "cmpl-123",
+		"model": "mistral-large-latest",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "Let me check that for you.",
+				"tool_calls": [{
+					"id": "call_abc",
+					"type": "function",
+					"function": {
+						"name": "unix",
+						"arguments": "{\"command\": \"ls -la\", \"final\": false}"
+					}
+				}]
+			},
+			"finish_reason": "tool_calls"
+		}]
+	}`
+
+	var mistralResp MistralResponse
+	err := json.Unmarshal([]byte(responseJSON), &mistralResp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "cmpl-123", mistralResp.ID)
+	assert.Equal(t, 1, len(mistralResp.Choices))
+
+	choice := mistralResp.Choices[0]
+	assert.Equal(t, "Let me check that for you.", choice.Message.Content)
+	assert.Equal(t, 1, len(choice.Message.ToolCalls))
+
+	toolCall := choice.Message.ToolCalls[0]
+	assert.Equal(t, "call_abc", toolCall.ID)
+	assert.Equal(t, "function", toolCall.Type)
+	assert.Equal(t, "unix", toolCall.Function.Name)
+	assert.Equal(t, `{"command": "ls -la", "final": false}`, toolCall.Function.Arguments)
+
+	var args map[string]any
+	err = json.Unmarshal([]byte(toolCall.Function.Arguments), &args)
+	assert.NoError(t, err)
+	assert.Equal(t, "ls -la", args["command"])
+	assert.Equal(t, false, args["final"])
+}
+
+func TestMistralToolCallResponseEmptyToolCalls(t *testing.T) {
+	responseJSON := `{
+		"id": "cmpl-123",
+		"model": "mistral-large-latest",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "Hello, how can I help?"
+			},
+			"finish_reason": "stop"
+		}]
+	}`
+
+	var mistralResp MistralResponse
+	err := json.Unmarshal([]byte(responseJSON), &mistralResp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(mistralResp.Choices))
+	assert.Equal(t, "Hello, how can I help?", mistralResp.Choices[0].Message.Content)
+	assert.Nil(t, mistralResp.Choices[0].Message.ToolCalls)
+}
+
+func TestMistralErrorResponseParse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"object":"error","message":"Invalid API key","type":"auth_error","code":"invalid_api_key"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("MISTRAL_API_KEY", "bad-key")
+	t.Setenv("MISTRAL_BASE_URL", server.URL)
+	modelID := "mistral-small-latest"
+	mc := NewMistralConnector(&modelID)
+	if mc == nil {
+		t.Fatal("Expected connector to be created")
+	}
+
+	mc.baseURL = server.URL
+
+	req, err := http.NewRequest("POST", server.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer bad-key")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	parseErr := mc.parseErrorResponse(resp)
+	assert.Error(t, parseErr)
+	assert.Contains(t, parseErr.Error(), "Invalid API key")
+}
+
+func TestMistralErrorResponseNonJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Internal Server Error"))
+	}))
+	defer server.Close()
+
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("MISTRAL_BASE_URL", server.URL)
+	modelID := "mistral-small-latest"
+	mc := NewMistralConnector(&modelID)
+	if mc == nil {
+		t.Fatal("Expected connector to be created")
+	}
+
+	mc.baseURL = server.URL
+
+	req, err := http.NewRequest("POST", server.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	parseErr := mc.parseErrorResponse(resp)
+	assert.Error(t, parseErr)
+	assert.Contains(t, parseErr.Error(), "status 500")
+}
+
+func TestMistralSupportsNativeToolCalling(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	modelID := "mistral-small-latest"
+	mc := NewMistralConnector(&modelID)
+	if mc == nil {
+		t.Fatal("Expected connector to be created")
+	}
+
+	assert.True(t, mc.SupportsNativeToolCalling())
+}
+
+func TestMistralQueryEmptyChoices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"1","model":"test","choices":[]}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("MISTRAL_BASE_URL", server.URL)
+	modelID := "mistral-small-latest"
+	mc := NewMistralConnector(&modelID)
+	if mc == nil {
+		t.Fatal("Expected connector to be created")
+	}
+
+	mc.baseURL = server.URL
+
+	req, err := http.NewRequest("POST", server.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	_, err = mc.parseCompletionResponse(resp)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no response from Mistral")
+}
+
+func TestMistralDeltaToolCallsNotParsed(t *testing.T) {
+	sseBody := `data: {"id":"1","choices":[{"delta":{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"unix","arguments":"{\"com"}}]}}]}
+
+data: {"id":"2","choices":[{"delta":{"tool_calls":[{"function":{"arguments":"mand\": \"ls\"}"}}]}}]}
+
+data: [DONE]
+`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(sseBody))
+	}))
+	defer server.Close()
+
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("MISTRAL_BASE_URL", server.URL)
+	modelID := "mistral-small-latest"
+	mc := NewMistralConnector(&modelID)
+	if mc == nil {
+		t.Fatal("Expected connector to be created")
+	}
+
+	req, err := http.NewRequest("POST", server.URL+"/v1/chat/completions", nil)
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Streaming handler ignores tool_calls in delta (only extracts content)
+	result, err := mc.handleStreamingResponse(resp, nil)
+	assert.NoError(t, err)
+	// Tool call deltas have no "content" field, so result should be empty
+	assert.Equal(t, "", result)
+}

--- a/internal/gui/settings_validation.go
+++ b/internal/gui/settings_validation.go
@@ -16,6 +16,7 @@ var supportedProviders = []string{
 	connector.BedrockProvider,
 	connector.GoogleProvider,
 	connector.LlamaProvider,
+	connector.MistralProvider,
 	connector.OllamaProvider,
 	connector.OpenaiProvider,
 }
@@ -50,6 +51,10 @@ func providerSetupHint(provider string) string {
 	case connector.GoogleProvider:
 		if os.Getenv("GOOGLE_API_KEY") == "" {
 			return "Google requires GOOGLE_API_KEY to be set."
+		}
+	case connector.MistralProvider:
+		if os.Getenv("MISTRAL_API_KEY") == "" {
+			return "Mistral requires MISTRAL_API_KEY to be set."
 		}
 	case connector.LlamaProvider:
 		return "Llama uses local GGUF model aliases from config.json under llama_models."


### PR DESCRIPTION
## Summary
Add Mistral AI as a supported provider to Terminal Agent.

## Changes

### New connector (`internal/connector/mistral.go`, 434 lines)
- Full chat completions via `POST /v1/chat/completions`
- SSE streaming with `MarkdownStreamRenderer` / `OnStream` callback integration
- Native tool calling (`SupportsNativeToolCalling() → true`), parse `arguments` from JSON string
- Auth via `MISTRAL_API_KEY`, custom endpoint via `MISTRAL_BASE_URL`
- Structured error response parsing with fallback to raw body / status text

### Tests (`internal/connector/mistral_test.go`, 484 lines)
17 tests covering: constructor (key present/absent, defaults, custom base URL), tool format conversion, message building, SSE parsing (normal, empty lines, non-data fields, no DONE), tool call response parse, error response parse (JSON + raw text), empty choices, delta tool_calls in streaming

### Registration
- `internal/connector/main.go` — `MistralProvider` case
- `internal/config/main.go` — `"mistral": "mistral-small-latest"` in defaults
- `internal/commands/config_cmd.go` — added to `supportedProviders`
- `internal/gui/settings_validation.go` — added to `supportedProviders` + setup hint

### Docs
- `docs/providers.md` — new Mistral section (setup, models, features)
- `docs/configuration.md` — env var table entry
- `README.md` — new Mistral section

## Testing
```
task test:unit  # all 17 Mistral tests + full suite pass
go build ./cmd/agent/  # clean build
```

## Usage
```sh
export MISTRAL_API_KEY=your_key
agent config set provider mistral
agent ask "Hello"
agent task "list files"
agent ask --stream "Write a haiku about code."
```