### PR TITLE
feat: add dedicated read tool

### DIFF
--- a/internal/agent/task_helpers.go
+++ b/internal/agent/task_helpers.go
@@ -125,7 +125,7 @@ func taskToolInputRequestsFinal(input map[string]any) bool {
 
 func isTaskDisplayOrientedTool(toolName string) bool {
 	switch toolName {
-	case tools.ToolNameUnix, tools.ToolNamePython, tools.ToolNameFileSearch:
+	case tools.ToolNameUnix, tools.ToolNamePython, tools.ToolNameFileSearch, tools.ToolNameRead:
 		return true
 	default:
 		return false

--- a/internal/tools/contextual_tools_test.go
+++ b/internal/tools/contextual_tools_test.go
@@ -93,3 +93,108 @@ func TestUnixToolRunSchemaWithContextUsesCurrentDir(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, currentDir, strings.TrimSpace(result))
 }
+
+func TestReadToolRunSchemaWithContextReadsFiles(t *testing.T) {
+	rootDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "hello.txt"), []byte("line one\nline two\nline three\n"), 0o644))
+
+	tool := NewReadTool(rootDir)
+	result, err := tool.RunSchemaWithContext(map[string]any{"path": "hello.txt"}, ToolExecutionContext{
+		RootDir:    rootDir,
+		CurrentDir: rootDir,
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, result, "1: line one")
+	assert.Contains(t, result, "2: line two")
+	assert.Contains(t, result, "3: line three")
+}
+
+func TestReadToolSupportsOffsetAndLimit(t *testing.T) {
+	rootDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "lines.txt"), []byte("a\nb\nc\nd\ne\n"), 0o644))
+
+	tool := NewReadTool(rootDir)
+	result, err := tool.RunSchemaWithContext(map[string]any{
+		"path":   "lines.txt",
+		"offset": 2,
+		"limit":  2,
+	}, ToolExecutionContext{RootDir: rootDir, CurrentDir: rootDir})
+
+	require.NoError(t, err)
+	assert.Contains(t, result, "2: b")
+	assert.Contains(t, result, "3: c")
+	assert.NotContains(t, result, "1: a")
+	assert.NotContains(t, result, "4: d")
+}
+
+func TestReadToolReturnsErrorForMissingFile(t *testing.T) {
+	rootDir := t.TempDir()
+	tool := NewReadTool(rootDir)
+	_, err := tool.RunSchemaWithContext(map[string]any{"path": "missing.txt"}, ToolExecutionContext{
+		RootDir:    rootDir,
+		CurrentDir: rootDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file not found")
+}
+
+func TestReadToolRejectsPathsOutsideRoot(t *testing.T) {
+	rootDir := t.TempDir()
+	currentDir := filepath.Join(rootDir, "nested")
+	require.NoError(t, os.MkdirAll(currentDir, 0o755))
+
+	tool := NewReadTool(rootDir)
+	_, err := tool.RunSchemaWithContext(map[string]any{"path": "../../etc/passwd"}, ToolExecutionContext{
+		RootDir:    rootDir,
+		CurrentDir: currentDir,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside working directory")
+}
+
+func TestReadToolResolvesPathsRelativeToCurrentDir(t *testing.T) {
+	rootDir := t.TempDir()
+	currentDir := filepath.Join(rootDir, "nested")
+	require.NoError(t, os.MkdirAll(currentDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(currentDir, "local.txt"), []byte("nested content"), 0o644))
+
+	tool := NewReadTool(rootDir)
+	result, err := tool.RunSchemaWithContext(map[string]any{"path": "local.txt"}, ToolExecutionContext{
+		RootDir:    rootDir,
+		CurrentDir: currentDir,
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, result, "1: nested content")
+}
+
+func TestReadToolHandlesEmptyFile(t *testing.T) {
+	rootDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "empty.txt"), []byte(""), 0o644))
+
+	tool := NewReadTool(rootDir)
+	result, err := tool.RunSchemaWithContext(map[string]any{"path": "empty.txt"}, ToolExecutionContext{
+		RootDir:    rootDir,
+		CurrentDir: rootDir,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "(empty file)", result)
+}
+
+func TestReadToolOffsetExceedsFileLength(t *testing.T) {
+	rootDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "short.txt"), []byte("only one line\n"), 0o644))
+
+	tool := NewReadTool(rootDir)
+	result, err := tool.RunSchemaWithContext(map[string]any{"path": "short.txt", "offset": 5}, ToolExecutionContext{
+		RootDir:    rootDir,
+		CurrentDir: rootDir,
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, result, "offset 5 exceeds file length")
+}

--- a/internal/tools/main.go
+++ b/internal/tools/main.go
@@ -60,12 +60,14 @@ func GetAllBuiltinTools(config config.Config) map[string]Tool {
 	fileEditTool := NewFileEditTool(workDir)
 	fileSearchTool := NewFileSearchTool(workDir)
 	pythonTool := NewPythonTool(workDir)
+	readTool := NewReadTool(workDir)
 
 	tools := map[string]Tool{
 		unixTool.Name():       unixTool,
 		fileEditTool.Name():   fileEditTool,
 		fileSearchTool.Name(): fileSearchTool,
 		pythonTool.Name():     pythonTool,
+		readTool.Name():       readTool,
 	}
 
 	// Add Websearch only if possible

--- a/internal/tools/main_test.go
+++ b/internal/tools/main_test.go
@@ -9,7 +9,7 @@ import (
 func TestBuiltinToolsIncludeNativeTools(t *testing.T) {
 	tools := GetAllBuiltinTools(config.NewDefaultConfig())
 
-	for _, name := range []string{ToolNameFileEdit, ToolNameFileSearch, ToolNamePython} {
+	for _, name := range []string{ToolNameFileEdit, ToolNameFileSearch, ToolNamePython, ToolNameRead} {
 		if tools[name] == nil {
 			t.Fatalf("expected builtin tool %q to be registered", name)
 		}

--- a/internal/tools/names.go
+++ b/internal/tools/names.go
@@ -5,5 +5,6 @@ const (
 	ToolNameFileEdit   = "file_edit"
 	ToolNameFileSearch = "file_search"
 	ToolNamePython     = "python"
+	ToolNameRead       = "read"
 	ToolNameWebsearch  = "websearch"
 )

--- a/internal/tools/read.go
+++ b/internal/tools/read.go
@@ -1,0 +1,168 @@
+package tools
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	readToolDescription = "Read the contents of a file with optional offset and limit for pagination."
+)
+
+type ReadTool struct {
+	name        string
+	description string
+	inputSchema map[string]any
+	helpText    string
+	workDir     string
+}
+
+func NewReadTool(workDir string) *ReadTool {
+	return &ReadTool{
+		name:        ToolNameRead,
+		description: readToolDescription,
+		inputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]string{
+					"type":        "string",
+					"description": "File path relative to the working directory (or absolute within it)",
+				},
+				"offset": map[string]string{
+					"type":        "integer",
+					"description": "Line number to start reading from (1-indexed, default 1)",
+				},
+				"limit": map[string]string{
+					"type":        "integer",
+					"description": "Maximum number of lines to read (default reads all lines from offset)",
+				},
+				"final": map[string]string{
+					"type":        "boolean",
+					"description": "Set to true only when the file contents themselves fully answer the user's request and should be returned directly without another model summary round.",
+				},
+			},
+			"required": []string{"path"},
+		},
+		helpText: "Read file contents with optional pagination.",
+		workDir:  workDir,
+	}
+}
+
+func (t *ReadTool) Name() string {
+	return t.name
+}
+
+func (t *ReadTool) Description() string {
+	return t.description
+}
+
+func (t *ReadTool) InputSchema() map[string]any {
+	return t.inputSchema
+}
+
+func (t *ReadTool) HelpText() string {
+	return t.helpText
+}
+
+func (t *ReadTool) Run(input *string) (string, error) {
+	if input == nil {
+		return "", fmt.Errorf("path is required")
+	}
+	return t.RunSchema(map[string]any{"path": *input})
+}
+
+func (t *ReadTool) RunSchema(input map[string]any) (string, error) {
+	return t.RunSchemaWithContext(input, ToolExecutionContext{RootDir: t.workDir, CurrentDir: t.workDir})
+}
+
+func (t *ReadTool) RunSchemaWithContext(input map[string]any, ctx ToolExecutionContext) (string, error) {
+	path, ok := input["path"].(string)
+	if !ok || strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+
+	resolvedPath, err := resolvePathInContext(path, ctx, t.workDir)
+	if err != nil {
+		return "", err
+	}
+
+	offset := 1
+	if rawOffset, ok := input["offset"]; ok {
+		switch v := rawOffset.(type) {
+		case int:
+			offset = v
+		case float64:
+			offset = int(v)
+		}
+	}
+	if offset < 1 {
+		offset = 1
+	}
+
+	limit := -1
+	if rawLimit, ok := input["limit"]; ok {
+		switch v := rawLimit.(type) {
+		case int:
+			limit = v
+		case float64:
+			limit = int(v)
+		}
+	}
+
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("file not found: %s", path)
+		}
+		return "", fmt.Errorf("failed to access file: %w", err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("path is a directory, not a file: %s", path)
+	}
+
+	file, err := os.Open(resolvedPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	lines := make([]string, 0)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		if lineNo < offset {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%d: %s", lineNo, scanner.Text()))
+		if limit > 0 && len(lines) >= limit {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	if len(lines) == 0 {
+		if lineNo == 0 {
+			return "(empty file)", nil
+		}
+		if offset > lineNo {
+			return fmt.Sprintf("offset %d exceeds file length (%d lines)", offset, lineNo), nil
+		}
+		return "(empty file)", nil
+	}
+
+	result := strings.Join(lines, "\n")
+	totalLines := lineNo
+	if limit > 0 && totalLines > offset+limit-1 {
+		result += fmt.Sprintf("\n\n[Showing lines %d-%d of %d total lines in %s]", offset, offset+limit-1, totalLines, filepath.Base(resolvedPath))
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
## Summary

Adds a `read` tool for reading file contents with offset/limit pagination — matching patterns from OpenCode, Pi, and Claude Code.

## Changes

### New File
- **`internal/tools/read.go`** — `ReadTool` implementing `Tool` + `ContextualTool`

### Modified Files
- **`internal/tools/names.go`** — added `ToolNameRead = "read"`
- **`internal/tools/main.go`** — registered `read` in `GetAllBuiltinTools()`
- **`internal/tools/main_test.go`** — added `ToolNameRead` to built-in check
- **`internal/tools/contextual_tools_test.go`** — 5 new tests

## Features
- `path` (required) — file path resolved within task root
- `offset` (optional, default 1) — line to start reading from (1-indexed)
- `limit` (optional) — max lines to return
- Output includes line numbers: `1: line content`
- Skips permission confirmation (read-only, same as `file_search`)
- Rejects paths outside task root directory

Closes #011