### PR TITLE
fix: separate thought and tool-call iteration limits in task loop

### DIFF
--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	MaxIterations             = 10
+	MaxToolCalls              = 10
+	MaxTurns                  = 50
 	maxTaskActionFallbackRuns = 2
 	UserClarificationToolName = "user_clarification"
 	ToolNameChangeDirectory   = "change_directory"
@@ -60,7 +61,9 @@ type taskToolOutput struct {
 type TaskState struct {
 	OriginalQuery string
 	Iterations    int
+	ToolCalls     int
 	MaxIterations int
+	MaxTurns      int
 	Phase         TaskPhase
 	Dirs          TaskDirs
 	Steps         []TaskStep
@@ -102,7 +105,7 @@ func (a *Agent) TaskWithOptionsResult(ctx context.Context, s string, options Tas
 		return TaskRunResult{}, err
 	}
 
-	for run.state.Phase == TaskPhaseRunning && run.state.Iterations < run.state.MaxIterations {
+	for run.state.Phase == TaskPhaseRunning && run.state.Iterations < run.state.MaxTurns && run.state.ToolCalls < run.state.MaxIterations {
 		run.state.Iterations++
 
 		result, done, err := a.runTaskIteration(ctx, logger, run)
@@ -135,10 +138,11 @@ func (a *Agent) newTaskExecutionState(query string, options TaskOptions) (*taskE
 	return &taskExecutionState{
 		state: &TaskState{
 			OriginalQuery: query,
-			MaxIterations: MaxIterations,
+			MaxIterations: MaxToolCalls,
+			MaxTurns:      MaxTurns,
 			Phase:         TaskPhaseRunning,
 			Dirs:          taskDirs,
-			Steps:         make([]TaskStep, 0, MaxIterations),
+			Steps:         make([]TaskStep, 0, MaxTurns),
 		},
 		confirmations:     confirmations,
 		successfulOutputs: make([]taskToolOutput, 0, 1),
@@ -188,6 +192,7 @@ func (a *Agent) handleTaskToolResponse(logger *zap.SugaredLogger, run *taskExecu
 
 	if response.ToolName == ToolNameChangeDirectory {
 		run.handleDirectoryChange(response, logger)
+		run.state.ToolCalls++
 		return TaskRunResult{}, false, nil
 	}
 
@@ -212,6 +217,7 @@ func (a *Agent) executeTaskTool(logger *zap.SugaredLogger, run *taskExecutionSta
 		return TaskRunResult{}, false, nil
 	}
 
+	run.state.ToolCalls++
 	run.recordSuccess(response, toolResult)
 	if response.ToolName == ToolNameFinalAnswer {
 		run.state.Phase = TaskPhaseCompleted
@@ -232,7 +238,7 @@ func (a *Agent) executeTaskTool(logger *zap.SugaredLogger, run *taskExecutionSta
 }
 
 func (a *Agent) finalizeTaskRun(ctx context.Context, run *taskExecutionState) (TaskRunResult, error) {
-	if run.state.Phase != TaskPhaseRunning || run.state.Iterations < run.state.MaxIterations {
+	if run.state.Phase != TaskPhaseRunning {
 		return TaskRunResult{}, fmt.Errorf("task ended without an explicit completion path")
 	}
 
@@ -698,7 +704,8 @@ func buildTaskPrompt(state *TaskState) string {
 	var prompt strings.Builder
 	fmt.Fprintf(&prompt, "Original task: %s\n\n", state.OriginalQuery)
 	fmt.Fprintf(&prompt, "Current phase: %s\n", state.Phase)
-	fmt.Fprintf(&prompt, "Iteration: %d of %d\n", state.Iterations, state.MaxIterations)
+	fmt.Fprintf(&prompt, "Turn: %d of %d\n", state.Iterations, state.MaxTurns)
+	fmt.Fprintf(&prompt, "Tool calls: %d of %d\n", state.ToolCalls, state.MaxIterations)
 	fmt.Fprintf(&prompt, "Task root directory: %s\n", state.Dirs.RootDir)
 	fmt.Fprintf(&prompt, "Current working directory: %s", state.Dirs.CurrentDir)
 
@@ -732,7 +739,7 @@ func (a *Agent) finalizeSummary(ctx context.Context, state *TaskState) (string, 
 		summary.WriteString(history)
 	}
 
-	summary.WriteString("\n\nI've reached the maximum number of iterations. Based on the above, provide a comprehensive final answer.")
+	summary.WriteString("\n\nI've reached the task budget limit. Based on the above, provide a comprehensive final answer.")
 
 	qParams := connector.QueryParams{
 		UserPrompt: StringPtr(summary.String()),

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -212,7 +212,9 @@ func TestBuildTaskPromptUsesOrderedStructuredHistory(t *testing.T) {
 	prompt := buildTaskPrompt(&TaskState{
 		OriginalQuery: "trace repeated tool calls",
 		Iterations:    3,
-		MaxIterations: MaxIterations,
+		ToolCalls:     2,
+		MaxIterations: MaxToolCalls,
+		MaxTurns:      MaxTurns,
 		Phase:         TaskPhaseRunning,
 		Dirs:          TaskDirs{RootDir: "/repo", CurrentDir: "/repo/internal"},
 		Steps: []TaskStep{
@@ -632,7 +634,7 @@ func TestTaskWithOptionsResultUsesSummaryFallbackAtMaxIterations(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "summary output", result.Response)
-	assert.Equal(t, MaxIterations, conn.queryToolCalls)
+	assert.Equal(t, MaxTurns, conn.queryToolCalls)
 	assert.Equal(t, 1, conn.queryCalls)
 }
 
@@ -652,7 +654,7 @@ func TestTaskWithOptionsResultReturnsErrorWhenSummaryFallbackFails(t *testing.T)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "summary failed")
-	assert.Equal(t, MaxIterations, conn.queryToolCalls)
+	assert.Equal(t, MaxTurns, conn.queryToolCalls)
 	assert.Equal(t, 1, conn.queryCalls)
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where 10 consecutive text-only thought responses would abort a task with "task ended without an explicit completion path" instead of continuing and attempting a summary.

## Problem

`MaxIterations` (10) counted every LLM response — including plain-text "thought" responses that don't call a tool. When the LLM gave 10 thoughts without a tool call (encouraged by the system prompt's "plan extensively" instruction), `finalizeTaskRun` would not run because it required `Iterations >= MaxIterations`, and the loop returned an error instead.

## Changes

### `internal/agent/task.go`
- Renamed `MaxIterations` constant → `MaxToolCalls` (10) for tool calls, added `MaxTurns` (50) for total LLM query guard
- `TaskState` now tracks `ToolCalls` separately from `Iterations` (turns), plus `MaxTurns`
- Main loop exits only when `ToolCalls >= MaxToolCalls` **OR** `turns >= MaxTurns`
- `finalizeTaskRun` always runs on loop exit (removed the `Iterations >= MaxIterations` gate)
- `buildTaskPrompt` shows both `Turn: X of Y` and `Tool calls: X of Y`
- `ToolCalls` incremented only on successful tool execution (not on validation failures, declined calls, or thought-only turns)

### `internal/agent/task_test.go`
- Updated test constants and `TaskState` fields to match new naming

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| 10 thought-only responses | Error: "task ended without an explicit completion path" | Continues up to 50 turns, then summarizes |
| 10 tool calls | Finalizes via summary | Finalizes via summary (unchanged) |
| Early exit mid-loop | Error | Attempts summary |

Closes #012