### PR TITLE
Fix task tool cancellation propagation

### DIFF
--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -268,10 +269,13 @@ func (a *Agent) executeTaskTool(ctx context.Context, logger *zap.SugaredLogger, 
 	if err := ctx.Err(); err != nil {
 		return TaskRunResult{}, false, err
 	}
-	toolResult, err := runTaskTool(tool, response.ToolInput, run.state.Dirs)
+	toolResult, err := runTaskTool(ctx, tool, response.ToolInput, run.state.Dirs)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return TaskRunResult{}, false, ctxErr
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return TaskRunResult{}, false, err
 		}
 		logger.Errorw("Tool execution failed", "tool", response.ToolName, "error", err)
 		run.recordFailure(response, err)

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -273,9 +272,6 @@ func (a *Agent) executeTaskTool(ctx context.Context, logger *zap.SugaredLogger, 
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return TaskRunResult{}, false, ctxErr
-		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return TaskRunResult{}, false, err
 		}
 		logger.Errorw("Tool execution failed", "tool", response.ToolName, "error", err)
 		run.recordFailure(response, err)

--- a/internal/agent/task_helpers.go
+++ b/internal/agent/task_helpers.go
@@ -28,9 +28,6 @@ func selectTaskRawOutput(outputs []taskToolOutput) taskToolOutput {
 }
 
 func runTaskTool(ctx context.Context, tool tools.Tool, input map[string]any, dirs TaskDirs) (string, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}

--- a/internal/agent/task_helpers.go
+++ b/internal/agent/task_helpers.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,12 +27,22 @@ func selectTaskRawOutput(outputs []taskToolOutput) taskToolOutput {
 	return taskToolOutput{}
 }
 
-func runTaskTool(tool tools.Tool, input map[string]any, dirs TaskDirs) (string, error) {
+func runTaskTool(ctx context.Context, tool tools.Tool, input map[string]any, dirs TaskDirs) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	execCtx := tools.ToolExecutionContext{
+		RootDir:    dirs.RootDir,
+		CurrentDir: dirs.CurrentDir,
+	}
+	if contextAwareTool, ok := tool.(tools.ContextAwareTool); ok {
+		return contextAwareTool.RunSchemaContext(ctx, input, execCtx)
+	}
 	if contextualTool, ok := tool.(tools.ContextualTool); ok {
-		return contextualTool.RunSchemaWithContext(input, tools.ToolExecutionContext{
-			RootDir:    dirs.RootDir,
-			CurrentDir: dirs.CurrentDir,
-		})
+		return contextualTool.RunSchemaWithContext(input, execCtx)
 	}
 	return tool.RunSchema(input)
 }

--- a/internal/agent/task_helpers_test.go
+++ b/internal/agent/task_helpers_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type contextAwareTaskTool struct {
+	receivedCtx   context.Context
+	receivedInput map[string]any
+	receivedExec  tools.ToolExecutionContext
+	legacyCalled  bool
+}
+
+func (t *contextAwareTaskTool) Name() string                { return "context_aware" }
+func (t *contextAwareTaskTool) Description() string         { return "" }
+func (t *contextAwareTaskTool) InputSchema() map[string]any { return map[string]any{} }
+func (t *contextAwareTaskTool) HelpText() string            { return "" }
+func (t *contextAwareTaskTool) RunSchema(map[string]any) (string, error) {
+	t.legacyCalled = true
+	return "legacy", nil
+}
+func (t *contextAwareTaskTool) Run(*string) (string, error) { return "legacy", nil }
+func (t *contextAwareTaskTool) RunSchemaContext(ctx context.Context, input map[string]any, execCtx tools.ToolExecutionContext) (string, error) {
+	t.receivedCtx = ctx
+	t.receivedInput = input
+	t.receivedExec = execCtx
+	return "context-aware", nil
+}
+
+type legacyTaskTool struct {
+	receivedInput map[string]any
+}
+
+func (t *legacyTaskTool) Name() string                { return "legacy" }
+func (t *legacyTaskTool) Description() string         { return "" }
+func (t *legacyTaskTool) InputSchema() map[string]any { return map[string]any{} }
+func (t *legacyTaskTool) HelpText() string            { return "" }
+func (t *legacyTaskTool) RunSchema(input map[string]any) (string, error) {
+	t.receivedInput = input
+	return "legacy", nil
+}
+func (t *legacyTaskTool) Run(*string) (string, error) { return "legacy", nil }
+
+func TestRunTaskToolPassesTaskContextToContextAwareTool(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	input := map[string]any{"command": "pwd"}
+	tool := &contextAwareTaskTool{}
+	dirs := TaskDirs{RootDir: "/repo", CurrentDir: "/repo/internal"}
+
+	output, err := runTaskTool(ctx, tool, input, dirs)
+
+	require.NoError(t, err)
+	assert.Equal(t, "context-aware", output)
+	assert.False(t, tool.legacyCalled)
+	assert.Equal(t, input, tool.receivedInput)
+	assert.Equal(t, tools.ToolExecutionContext{RootDir: dirs.RootDir, CurrentDir: dirs.CurrentDir}, tool.receivedExec)
+	assert.Equal(t, ctx, tool.receivedCtx)
+	cancel()
+	require.ErrorIs(t, tool.receivedCtx.Err(), context.Canceled)
+}
+
+func TestRunTaskToolFallsBackToLegacyTool(t *testing.T) {
+	input := map[string]any{"value": "ok"}
+	tool := &legacyTaskTool{}
+
+	output, err := runTaskTool(context.Background(), tool, input, TaskDirs{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "legacy", output)
+	assert.Equal(t, input, tool.receivedInput)
+}

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -431,6 +431,51 @@ func TestTaskWithOptionsResultDoesNotExecuteToolAfterContextCanceled(t *testing.
 	assert.Empty(t, tool.inputs)
 }
 
+func TestTaskWithOptionsResultCancelsActiveUnixCommand(t *testing.T) {
+	utils.Logger = zap.NewNop()
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+	interaction := &fakeTaskInteraction{decision: TaskConfirmationDecision{Allowed: true}}
+	conn := &scriptedToolConnector{responses: []connector.LlmResponseWithTools{
+		{
+			ToolUse:  true,
+			ToolName: tools.ToolNameUnix,
+			ToolInput: map[string]any{
+				"command": "sleep 5",
+			},
+		},
+	}}
+	sysPrompt := "task system prompt"
+	agent := &Agent{
+		Connector: conn,
+		Tools: map[string]tools.Tool{
+			tools.ToolNameUnix: tools.NewUnixTool(nil),
+		},
+		systemPromptTask: &sysPrompt,
+		maxTokens:        MaxTokens,
+	}
+	steps := []TaskStep{}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := agent.TaskWithOptionsResult(ctx, "run a long command", TaskOptions{
+		Interaction: interaction,
+		Dirs:        TaskDirs{RootDir: rootDir, CurrentDir: rootDir},
+		OnStep: func(step TaskStep) {
+			steps = append(steps, step)
+		},
+	})
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 2*time.Second)
+	assert.Empty(t, steps)
+	assert.Equal(t, 1, conn.queryToolCalls)
+	require.Len(t, interaction.confirmations, 1)
+	assert.Equal(t, `unix("sleep 5")`, interaction.confirmations[0].Action)
+}
+
 func TestBuildTaskPromptUsesOrderedStructuredHistory(t *testing.T) {
 	prompt := buildTaskPrompt(&TaskState{
 		OriginalQuery: "trace repeated tool calls",

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -11,10 +12,21 @@ type BashExecutor struct {
 }
 
 func (b *BashExecutor) Exec(code string) (string, error) {
+	return b.ExecContext(context.Background(), code)
+}
+
+func (b *BashExecutor) ExecContext(ctx context.Context, code string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 
 	// Prepare command for execution
 	fmt.Printf("Executing Unix command: %s\n", code)
-	cmd := exec.Command("bash", "-c", code)
+	cmd := exec.CommandContext(ctx, "bash", "-c", code)
+	configureCommandCancellation(cmd)
 
 	// Set working directory if provided
 	if b.workDir != "" {
@@ -25,6 +37,9 @@ func (b *BashExecutor) Exec(code string) (string, error) {
 	output, err := cmd.CombinedOutput()
 	strOutput := string(output)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return strOutput, ctxErr
+		}
 		return strOutput, fmt.Errorf("bash command returned non-zero status: %w\nOutput: %s", err, strOutput)
 	}
 

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -16,9 +16,6 @@ func (b *BashExecutor) Exec(code string) (string, error) {
 }
 
 func (b *BashExecutor) ExecContext(ctx context.Context, code string) (string, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}

--- a/internal/tools/executor_test.go
+++ b/internal/tools/executor_test.go
@@ -1,11 +1,13 @@
 package tools
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,4 +36,17 @@ func TestBashExecutorDoesNotPrintWorkingDirectory(t *testing.T) {
 	assert.Contains(t, string(printed), "Executing Unix command: pwd")
 	assert.NotContains(t, string(printed), "Working directory:")
 	assert.False(t, strings.Contains(output, "Working directory:"))
+}
+
+func TestBashExecutorExecContextCancelsLongRunningCommand(t *testing.T) {
+	executor := &BashExecutor{}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := executor.ExecContext(ctx, "sleep 5")
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 2*time.Second)
 }

--- a/internal/tools/executor_unix.go
+++ b/internal/tools/executor_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package tools
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureCommandCancellation(cmd *exec.Cmd) {
+	// Run bash in its own process group so context cancellation kills the shell
+	// and child processes such as sleep, not just the immediate shell process.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+}

--- a/internal/tools/executor_unix.go
+++ b/internal/tools/executor_unix.go
@@ -7,17 +7,19 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 )
 
 func configureCommandCancellation(cmd *exec.Cmd) {
 	// Run bash in its own process group so context cancellation kills the shell
 	// and child processes such as sleep, not just the immediate shell process.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.WaitDelay = 3 * time.Second
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return os.ErrProcessDone
 		}
-		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 		if errors.Is(err, syscall.ESRCH) {
 			return os.ErrProcessDone
 		}

--- a/internal/tools/executor_windows.go
+++ b/internal/tools/executor_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package tools
+
+import "os/exec"
+
+func configureCommandCancellation(_ *exec.Cmd) {}

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -1,5 +1,7 @@
 package tools
 
+import "context"
+
 type Tool interface {
 
 	// Runs the tool on the input. Execpts the input to be in accordance with the input schema.
@@ -42,8 +44,18 @@ type ContextualTool interface {
 	RunSchemaWithContext(input map[string]any, ctx ToolExecutionContext) (string, error)
 }
 
+type ContextAwareTool interface {
+	Tool
+	RunSchemaContext(ctx context.Context, input map[string]any, execCtx ToolExecutionContext) (string, error)
+}
+
 type CodeExecutor interface {
 	Exec(code string) (string, error)
+}
+
+type ContextAwareCodeExecutor interface {
+	CodeExecutor
+	ExecContext(ctx context.Context, code string) (string, error)
 }
 
 type LlmResponseWithTools struct {

--- a/internal/tools/unix.go
+++ b/internal/tools/unix.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -128,18 +129,36 @@ func (u *UnixTool) HelpText() string {
 }
 
 func (u *UnixTool) ExecCode(code string) (string, error) {
-	return u.execCodeWithExecutor(code, u.executor)
+	return u.execCodeWithExecutorContext(context.Background(), code, u.executor)
 }
 
 func (u *UnixTool) execCodeWithExecutor(code string, executor CodeExecutor) (string, error) {
+	return u.execCodeWithExecutorContext(context.Background(), code, executor)
+}
+
+func (u *UnixTool) execCodeWithExecutorContext(ctx context.Context, code string, executor CodeExecutor) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	fmt.Printf("Tool: ExecCode: code: %s\n", code)
 	if code == "" {
 		return "", fmt.Errorf("no Unix command found in the response")
 	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 
-	cmdOutput, err := executor.Exec(code)
+	var (
+		cmdOutput string
+		err       error
+	)
+	if contextAwareExecutor, ok := executor.(ContextAwareCodeExecutor); ok {
+		cmdOutput, err = contextAwareExecutor.ExecContext(ctx, code)
+	} else {
+		cmdOutput, err = executor.Exec(code)
+	}
 	if err != nil {
-		return "", fmt.Errorf("failed to execute Unix command: %v", err)
+		return "", fmt.Errorf("failed to execute Unix command: %w", err)
 	}
 	return cmdOutput, nil
 }
@@ -154,14 +173,18 @@ func (u *UnixTool) RunSchema(input map[string]any) (string, error) {
 }
 
 func (u *UnixTool) RunSchemaWithContext(input map[string]any, ctx ToolExecutionContext) (string, error) {
+	return u.RunSchemaContext(context.Background(), input, ctx)
+}
+
+func (u *UnixTool) RunSchemaContext(ctx context.Context, input map[string]any, execCtx ToolExecutionContext) (string, error) {
 	cmd, ok := input["command"].(string)
 	if !ok {
 		return "", fmt.Errorf("failed to extract command from tool input")
 	}
 
 	executor := u.executor
-	if ctx.CurrentDir != "" {
-		executor = &BashExecutor{workDir: ctx.CurrentDir}
+	if execCtx.CurrentDir != "" {
+		executor = &BashExecutor{workDir: execCtx.CurrentDir}
 	}
-	return u.execCodeWithExecutor(cmd, executor)
+	return u.execCodeWithExecutorContext(ctx, cmd, executor)
 }

--- a/internal/tools/unix.go
+++ b/internal/tools/unix.go
@@ -137,9 +137,6 @@ func (u *UnixTool) execCodeWithExecutor(code string, executor CodeExecutor) (str
 }
 
 func (u *UnixTool) execCodeWithExecutorContext(ctx context.Context, code string, executor CodeExecutor) (string, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	fmt.Printf("Tool: ExecCode: code: %s\n", code)
 	if code == "" {
 		return "", fmt.Errorf("no Unix command found in the response")


### PR DESCRIPTION
## Summary
- pass task contexts into tool execution via optional context-aware interfaces
- execute unix commands with CommandContext and kill Unix process groups on cancellation
- add tests for cancellation propagation and legacy tool compatibility

Closes #28

## Tests
- go test ./internal/tools ./internal/agent
- task test:unit
- git diff --check

Snyk: `snyk code test` could not run locally because `snyk` is not installed.