### PR TITLE
feat: explicit timeout semantics for task execution (#31)

### DIFF
--- a/docs/commands/task.md
+++ b/docs/commands/task.md
@@ -67,8 +67,37 @@ You will be asked to confirm each execution step, and the agent may also ask fol
 | `--log` | `-l` | `false` | Whether to log the input and output to a file |
 | `--plain` | `-k` | `false` | Render the response as plain text (no markdown) |
 | `--allow` |  | `[]` | Allow actions without confirmation (repeatable, glob-based) |
+| `--timeout` |  | unlimited | Maximum duration for the whole task run (Go duration, e.g. `90s`, `15m`, `2h`); `0` means no timeout |
 
 Action strings use a function-style format, e.g. `unix("aws login sso")` or `file_edit("README.md", operation="write")`. String values use glob matching against the full value: `*` matches any sequence, `?` matches a single character, and character classes like `[ab]` or `[a-z]` are supported. Escape glob metacharacters with `\` when you want a literal match, for example `unix("ls -d \\*/")`. To constrain keys, use `allowKeys=["region", "profile", "read*"]`, and key values can use the same glob syntax, e.g. `region="us-*"`.
+
+## Task Timeout
+
+By default a task runs with **no timeout** — useful for long-running, foreground work such as monitoring (`agent task "watch CPU usage and tell me when it crosses 50%"`). The run stops only when the task completes, you cancel it (Ctrl-C), or it hits the internal max tool-call/turn limits.
+
+Use `--timeout` to bound the whole run with a Go duration string:
+
+```sh
+# Stop the task after 15 minutes
+agent task --timeout 15m "tail the log and summarize errors as they appear"
+
+# Short bound for a quick job
+agent task --timeout 90s "run the test suite and report failures"
+```
+
+Resolution order, highest priority first:
+
+1. The `--timeout` flag (including an explicit `--timeout 0`, which forces unlimited even when a config default is set).
+2. The `task_timeout` value in `~/.config/terminal-agent/config.json` (a duration string such as `"15m"`).
+3. The built-in default: unlimited.
+
+```json
+{
+  "task_timeout": "15m"
+}
+```
+
+When a task stops because its timeout elapsed, the run fails with a distinct timeout error so it is distinguishable from tool or model failures. The resolved timeout (`"15m"` or `"unlimited"`) is recorded in the session log header so you can audit why a task stopped. Cancelling the caller's context (e.g. pressing Ctrl-C) always takes precedence over the timeout.
 
 ## Safety Features
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -12,6 +12,11 @@ import (
 // ErrEmptyQuery is returned when the query is empty.
 var ErrEmptyQuery = fmt.Errorf("empty query")
 
+// ErrTaskTimeout is returned when a task run is stopped because its configured
+// timeout elapsed. It is distinct from caller context cancellation and from
+// tool or model failures so callers can identify timeout-driven stops.
+var ErrTaskTimeout = fmt.Errorf("task timed out")
+
 const MaxTokens = 400
 
 type Agent struct {

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -29,6 +29,9 @@ type TaskOptions struct {
 	Dirs        TaskDirs
 	Interaction TaskInteraction
 	OnStep      func(TaskStep)
+	// Timeout bounds the whole task run. A value of 0 means no task-level
+	// timeout (unlimited). Caller context cancellation always takes precedence.
+	Timeout time.Duration
 }
 
 type TaskRunResult struct {
@@ -130,9 +133,24 @@ func (r TaskRunResult) DisplayText() string {
 }
 
 func (a *Agent) TaskWithOptionsResult(ctx context.Context, s string, options TaskOptions) (TaskRunResult, error) {
+	// A positive timeout bounds the whole run; 0 means unlimited so the caller's
+	// context passes through untouched. WithTimeoutCause lets us distinguish a
+	// timeout-driven stop (cause == ErrTaskTimeout) from caller cancellation.
+	if options.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeoutCause(ctx, options.Timeout, ErrTaskTimeout)
+		defer cancel()
+	}
+
+	result, err := a.runTaskLoop(ctx, s, options)
+	if err != nil && context.Cause(ctx) == ErrTaskTimeout {
+		return TaskRunResult{}, ErrTaskTimeout
+	}
+	return result, err
+}
+
+func (a *Agent) runTaskLoop(ctx context.Context, s string, options TaskOptions) (TaskRunResult, error) {
 	logger := log.Sugar()
-	ctx, cancel := context.WithTimeout(ctx, 900*time.Second)
-	defer cancel()
 	if err := ctx.Err(); err != nil {
 		return TaskRunResult{}, err
 	}

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -476,6 +476,80 @@ func TestTaskWithOptionsResultCancelsActiveUnixCommand(t *testing.T) {
 	assert.Equal(t, `unix("sleep 5")`, interaction.confirmations[0].Action)
 }
 
+// blockingTaskConnector blocks each query until the context is done, then
+// returns the context error. It is used to exercise task-level timeouts.
+type blockingTaskConnector struct {
+	queryCalls     int
+	queryToolCalls int
+}
+
+func (c *blockingTaskConnector) Query(ctx context.Context, _ *connector.QueryParams) (string, error) {
+	c.queryCalls++
+	<-ctx.Done()
+	return "", ctx.Err()
+}
+
+func (c *blockingTaskConnector) QueryWithTool(ctx context.Context, _ *connector.QueryParams, _ map[string]tools.Tool) (connector.LlmResponseWithTools, error) {
+	c.queryToolCalls++
+	<-ctx.Done()
+	return connector.LlmResponseWithTools{}, ctx.Err()
+}
+
+func (c *blockingTaskConnector) SupportsNativeToolCalling() bool {
+	return true
+}
+
+func TestTaskWithOptionsResultReturnsErrTaskTimeoutWhenTimeoutElapses(t *testing.T) {
+	utils.Logger = zap.NewNop()
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+	conn := &blockingTaskConnector{}
+	sysPrompt := "task system prompt"
+	agent := &Agent{
+		Connector:        conn,
+		Tools:            map[string]tools.Tool{},
+		systemPromptTask: &sysPrompt,
+		maxTokens:        MaxTokens,
+	}
+
+	start := time.Now()
+	_, err := agent.TaskWithOptionsResult(context.Background(), "keep going forever", TaskOptions{
+		Timeout: 100 * time.Millisecond,
+		Dirs:    TaskDirs{RootDir: rootDir, CurrentDir: rootDir},
+	})
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, ErrTaskTimeout)
+	assert.NotErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, 2*time.Second)
+}
+
+func TestTaskWithOptionsResultCallerCancellationTakesPrecedenceOverTimeout(t *testing.T) {
+	utils.Logger = zap.NewNop()
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	conn := &cancelingTaskConnector{
+		cancel:   cancel,
+		response: connector.LlmResponseWithTools{Response: "still thinking"},
+	}
+	sysPrompt := "task system prompt"
+	agent := &Agent{
+		Connector:        conn,
+		Tools:            map[string]tools.Tool{},
+		systemPromptTask: &sysPrompt,
+		maxTokens:        MaxTokens,
+	}
+
+	_, err := agent.TaskWithOptionsResult(ctx, "keep going", TaskOptions{
+		Timeout: 10 * time.Second,
+		Dirs:    TaskDirs{RootDir: rootDir, CurrentDir: rootDir},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, ErrTaskTimeout)
+}
+
 func TestBuildTaskPromptUsesOrderedStructuredHistory(t *testing.T) {
 	prompt := buildTaskPrompt(&TaskState{
 		OriginalQuery: "trace repeated tool calls",

--- a/internal/app/task.go
+++ b/internal/app/task.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	internalagent "github.com/laszukdawid/terminal-agent/internal/agent"
 	"github.com/laszukdawid/terminal-agent/internal/config"
@@ -22,7 +23,18 @@ type TaskRequest struct {
 	WorkingDir     string
 	Allow          []string
 	Device         string
-	Config         config.Config
+	// Timeout bounds the whole task run. 0 means no task-level timeout (unlimited).
+	Timeout time.Duration
+	Config  config.Config
+}
+
+// formatTaskTimeout renders a task timeout for the session log meta header.
+// A zero duration is reported as "unlimited".
+func formatTaskTimeout(d time.Duration) string {
+	if d <= 0 {
+		return "unlimited"
+	}
+	return d.String()
 }
 
 type TaskResult struct {
@@ -39,7 +51,9 @@ func (s *service) TaskEvents(ctx context.Context, req TaskRequest) (<-chan Event
 	}
 
 	events := make(chan Event)
-	recorder := sessionlog.New(SessionDir(), buildMeta("task", req.Provider, req.Model, req.WorkingDir, req.Message))
+	meta := buildMeta("task", req.Provider, req.Model, req.WorkingDir, req.Message)
+	meta.TaskTimeout = formatTaskTimeout(req.Timeout)
+	recorder := sessionlog.New(SessionDir(), meta)
 	interaction := &taskEventInteraction{ctx: ctx, events: events}
 
 	go s.runTaskEvents(ctx, req, interaction, recorder, events)
@@ -115,6 +129,7 @@ func executeTask(ctx context.Context, req TaskRequest, interaction internalagent
 		Allow:       req.Allow,
 		Interaction: interaction,
 		OnStep:      onStep,
+		Timeout:     req.Timeout,
 		Dirs: internalagent.TaskDirs{
 			RootDir:    taskRootDir,
 			CurrentDir: taskRootDir,

--- a/internal/app/task_test.go
+++ b/internal/app/task_test.go
@@ -4,11 +4,18 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/laszukdawid/terminal-agent/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestFormatTaskTimeout(t *testing.T) {
+	assert.Equal(t, "unlimited", formatTaskTimeout(0))
+	assert.Equal(t, "15m0s", formatTaskTimeout(15*time.Minute))
+	assert.Equal(t, "1m30s", formatTaskTimeout(90*time.Second))
+}
 
 func TestResolveTaskRootDirUsesExplicitRequestWorkingDir(t *testing.T) {
 	requestDir := t.TempDir()

--- a/internal/commands/task_cmd.go
+++ b/internal/commands/task_cmd.go
@@ -49,6 +49,15 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 				allow = *allowList
 			}
 
+			// Resolve the task timeout: an explicit --timeout (including 0 =
+			// unlimited) wins; otherwise fall back to the configured default.
+			taskTimeout := config.GetTaskTimeout()
+			if flags.Changed("timeout") {
+				if flagTimeout, err := flags.GetDuration("timeout"); err == nil {
+					taskTimeout = flagTimeout
+				}
+			}
+
 			events, err := service.TaskEvents(ctx, app.TaskRequest{
 				Message:        userRequest,
 				Provider:       *provider,
@@ -57,6 +66,7 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 				WorkingDir:     taskWorkingDir,
 				Allow:          allow,
 				Device:         device,
+				Timeout:        taskTimeout,
 				Config:         config,
 			})
 			if err != nil {
@@ -118,6 +128,10 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 	modelID = cmd.Flags().StringP("model", "m", config.GetDefaultModelId(), "The model ID to use for the question")
 	promptFlag = cmd.Flags().String("prompt", "", "Custom system prompt (overrides file-based and default prompts)")
 	allowList = cmd.Flags().StringArray("allow", []string{}, "Allow exact action without confirmation (repeatable)")
+
+	// 'timeout' flag bounds the whole task run (Go duration, e.g. 15m). 0 means unlimited.
+	// Defaults to unlimited unless task_timeout is set in config.
+	cmd.Flags().Duration("timeout", 0, "Maximum task duration (e.g. 90s, 15m, 2h); 0 means no timeout")
 
 	// 'print' flag whether to print response to the stdout (default: true)
 	cmd.Flags().BoolP("print", "x", true, "Print the response to the stdout")

--- a/internal/commands/task_cmd_test.go
+++ b/internal/commands/task_cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/laszukdawid/terminal-agent/internal/app"
 	"github.com/laszukdawid/terminal-agent/internal/config"
@@ -130,4 +131,69 @@ func TestTaskCommandHandlesInteractiveEvents(t *testing.T) {
 	assert.Contains(t, output.String(), "Execute the following action?")
 	assert.Contains(t, output.String(), "Need clarification: Which directory?")
 	assert.Contains(t, output.String(), "done")
+}
+
+// runTaskCommandCapture runs the task command with the given config and args,
+// returning the TaskRequest the service received.
+func runTaskCommandCapture(t *testing.T, cfg config.Config, args ...string) app.TaskRequest {
+	t.Helper()
+	originalNewService := newService
+	defer func() { newService = originalNewService }()
+
+	var captured app.TaskRequest
+	newService = func() app.Service {
+		return &fakeTaskService{events: func(_ context.Context, req app.TaskRequest) (<-chan app.Event, error) {
+			captured = req
+			ch := make(chan app.Event)
+			go func() {
+				defer close(ch)
+				ch <- app.Event{Type: app.EventCompleted, FinalOutput: "done", Status: req.Message}
+			}()
+			return ch, nil
+		}}
+	}
+
+	cmd := NewTaskCommand(cfg)
+	cmd.SetIn(bytes.NewBufferString(""))
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.Flags().String("device", "", "")
+	cmd.SetArgs(args)
+
+	require.NoError(t, cmd.ExecuteContext(context.Background()))
+	return captured
+}
+
+func TestTaskCommandResolvesTimeout(t *testing.T) {
+	t.Run("defaults to unlimited (zero) when neither flag nor config set", func(t *testing.T) {
+		req := runTaskCommandCapture(t, config.NewDefaultConfig(), "do", "something")
+		assert.Equal(t, time.Duration(0), req.Timeout)
+	})
+
+	t.Run("uses --timeout flag when provided", func(t *testing.T) {
+		req := runTaskCommandCapture(t, config.NewDefaultConfig(), "--timeout", "30s", "do", "something")
+		assert.Equal(t, 30*time.Second, req.Timeout)
+	})
+
+	t.Run("falls back to config when flag absent", func(t *testing.T) {
+		cfg := config.NewDefaultConfig()
+		cfg.TaskTimeout = "5m"
+		req := runTaskCommandCapture(t, cfg, "do", "something")
+		assert.Equal(t, 5*time.Minute, req.Timeout)
+	})
+
+	t.Run("flag overrides config", func(t *testing.T) {
+		cfg := config.NewDefaultConfig()
+		cfg.TaskTimeout = "5m"
+		req := runTaskCommandCapture(t, cfg, "--timeout", "1m", "do", "something")
+		assert.Equal(t, time.Minute, req.Timeout)
+	})
+
+	t.Run("explicit --timeout 0 overrides config back to unlimited", func(t *testing.T) {
+		cfg := config.NewDefaultConfig()
+		cfg.TaskTimeout = "5m"
+		req := runTaskCommandCapture(t, cfg, "--timeout", "0", "do", "something")
+		assert.Equal(t, time.Duration(0), req.Timeout)
+	})
 }

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	log "github.com/laszukdawid/terminal-agent/internal/utils"
 	"github.com/spf13/cobra"
@@ -29,6 +30,7 @@ type Config interface {
 	GetWorkingDir() string
 	SetWorkingDir(string) error
 	GetMaxTokens() int
+	GetTaskTimeout() time.Duration
 	GetMemory() bool
 	SetMemory(bool) error
 	GetPermissions() Permissions
@@ -44,6 +46,7 @@ type config struct {
 	McpFilePath     string            `json:"mcp_file_path"`
 	WorkingDir      string            `json:"working_dir"`
 	MaxTokens       int               `json:"max_tokens"`
+	TaskTimeout     string            `json:"task_timeout,omitempty"`
 	Memory          bool              `json:"memory"`
 	ProjectContext  *bool             `json:"project_context,omitempty"`
 	Permissions     Permissions       `json:"permissions,omitempty"`
@@ -223,6 +226,20 @@ func (config *config) GetMaxTokens() int {
 		return NewDefaultConfig().MaxTokens
 	}
 	return config.MaxTokens
+}
+
+// GetTaskTimeout returns the configured default task timeout. An empty value or
+// an unparseable duration string yields 0, which the agent treats as unlimited.
+func (config *config) GetTaskTimeout() time.Duration {
+	if config.TaskTimeout == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(config.TaskTimeout)
+	if err != nil {
+		log.Warnw("Invalid task_timeout in config, treating as unlimited", "value", config.TaskTimeout, "error", err)
+		return 0
+	}
+	return d
 }
 
 func (config *config) SetWorkingDir(path string) error {

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -196,5 +197,24 @@ func TestGetProjectContext(t *testing.T) {
 		val := false
 		cfg.ProjectContext = &val
 		assert.False(t, cfg.GetProjectContext())
+	})
+}
+
+func TestGetTaskTimeout(t *testing.T) {
+	t.Run("defaults to zero (unlimited) when unset", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		assert.Equal(t, time.Duration(0), cfg.GetTaskTimeout())
+	})
+
+	t.Run("parses a valid duration string", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		cfg.TaskTimeout = "15m"
+		assert.Equal(t, 15*time.Minute, cfg.GetTaskTimeout())
+	})
+
+	t.Run("returns zero (unlimited) on invalid duration string", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		cfg.TaskTimeout = "not-a-duration"
+		assert.Equal(t, time.Duration(0), cfg.GetTaskTimeout())
 	})
 }

--- a/internal/sessionlog/main.go
+++ b/internal/sessionlog/main.go
@@ -40,14 +40,17 @@ const (
 
 // Meta is the provenance header written as the first line of every session file.
 type Meta struct {
-	RunID     string    `json:"run_id"`
-	Kind      string    `json:"kind"`
-	User      string    `json:"user,omitempty"`
-	Cwd       string    `json:"cwd,omitempty"`
-	Provider  string    `json:"provider,omitempty"`
-	Model     string    `json:"model,omitempty"`
-	Command   string    `json:"command,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	RunID    string `json:"run_id"`
+	Kind     string `json:"kind"`
+	User     string `json:"user,omitempty"`
+	Cwd      string `json:"cwd,omitempty"`
+	Provider string `json:"provider,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Command  string `json:"command,omitempty"`
+	// TaskTimeout records the resolved task-level timeout for task runs
+	// (e.g. "15m" or "unlimited"); empty for non-task runs.
+	TaskTimeout string    `json:"task_timeout,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 // Record is a single line in a session log file.


### PR DESCRIPTION
Closes #31.

## Summary

Task runs previously had a hidden, hardcoded 900s context timeout in `TaskWithOptionsResult`. This makes task timeout behavior **explicit, configurable, documented, and observable**.

Per the design discussion, the **default is unlimited** (no timeout) — long-running foreground work like monitoring is supported out of the box, and a bound is opt-in. This intentionally departs from the issue's "preserve the 15m default" wording; see the design spec for the rationale.

## Behavior

- Resolution precedence (highest first): `--timeout` flag → `task_timeout` in `config.json` → unlimited.
- Format is a Go duration string everywhere (`90s`, `15m`, `2h`).
- `0` means unlimited — the natural zero, no pointer/sentinel needed. `--timeout 0` explicitly overrides a config default back to unlimited.
- **Caller context cancellation always takes precedence** over the timeout (via `context.WithTimeoutCause`: a parent cancellation yields `context.Canceled`, a timeout yields `ErrTaskTimeout`).
- Timeout stops surface a distinct `ErrTaskTimeout`, distinguishable from tool/model failures.
- The resolved timeout (`"15m"` / `"unlimited"`) is recorded in the session-log meta header.

## Changes

| Layer | Change |
|-------|--------|
| `internal/config` | `task_timeout` field + `GetTaskTimeout()` (invalid/empty → unlimited) |
| `internal/agent` | `TaskOptions.Timeout`, exported `ErrTaskTimeout`, conditional `WithTimeoutCause` (removed hardcoded 900s) |
| `internal/app` | `TaskRequest.Timeout` wiring + session-log meta `task_timeout` |
| `internal/sessionlog` | `Meta.TaskTimeout` field |
| `internal/commands` | `--timeout` flag with `flags.Changed` precedence over config |
| `docs/commands/task.md` | flag row + "Task Timeout" section |

## Testing

Built with TDD (each test watched fail before implementing). Covers: default unlimited, custom timeout fires → `ErrTaskTimeout`, caller-cancellation precedence, flag-vs-config precedence, `--timeout 0` override, config getter parsing.

`go test ./internal/...` passes; `go vet` and `gofmt -l` clean.

A design spec is included at `docs/superpowers/specs/2026-05-29-task-timeout-semantics-design.md`.