### PR TITLE
feat: capability-based tool permissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,15 @@ Terminal Agent is a CLI-first AI assistant that lets you collaborate with large 
 
 Tool execution permissions can be set in `~/.config/terminal-agent/config.json` and in project-local `.terminal-agent.json` files. Local configs are discovered by walking from the current working directory up to the filesystem root; the closest file wins when priorities overlap. Permissions use the same action expression format shown in confirmations (for example `unix("aws sso login", profile="dev")`) and support `allow`, `deny`, and `ask` lists. When prompted, `yes!` or `no!` will remember a decision by writing to the nearest `.terminal-agent.json`, falling back to the global config when no local file exists.
 
+Whether a tool prompts by default (when no `allow`/`deny`/`ask` rule matches) is driven by a per-tool **permission category** rather than a hardcoded list. Tools declare their category via the optional `tools.CategorizedTool` interface (`PermissionCategory()` returning `read`, `write`, or `execute`):
+
+- **read** (`read`, `file_search`, `websearch`, `ask_user`, `final_answer`) — never prompts.
+- **write** (`file_edit`) — does not prompt when the target path resolves inside the task workspace root; prompts otherwise. `file_edit` is already physically confined to the root by `ensureWithinRoot`, so the prompt branch is a backstop for future write tools.
+- **execute** (`unix`, `python`) — always prompts; arbitrary effect.
+- **undeclared** (MCP tools, any new tool not implementing the interface) — treated as `execute` and gated by default. This is deliberate: a tool with no declared category must not run silently.
+
+The `allow`/`deny`/`ask` rule engine is unchanged and remains the override layer on top of these category defaults: `ask` always prompts, `deny` beats `allow` at equal-or-higher priority, and matched decisions are cached per run. The category only decides the fallback when no rule matches. See `permissionCategoryFor`/`confirmTool` in `internal/agent/task.go` and `ConfirmWithDefault` in `internal/agent/confirmation.go`.
+
 The repo is structured around the Go implementation of the binary (see `cmd/` and `internal/`), plus documentation in `docs/` that backs the published site. Installation can happen via Homebrew, downloading release archives, `go install`, or building from source with Taskfile tasks such as `task build`/`task install`.
 
 ## Contribution Conventions

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,19 @@ Terminal Agent supports tool execution permissions via the `permissions` key in 
 unix("aws sso login", profile="dev")
 ```
 
+### Default Behavior by Tool Category
+
+When no `allow`, `deny`, or `ask` rule matches an action, whether Terminal Agent prompts is decided by the tool's **permission category**:
+
+| Category | Tools | Default when no rule matches |
+| --- | --- | --- |
+| `read` | `read`, `file_search`, `websearch` | Runs without prompting |
+| `write` | `file_edit` | Runs without prompting when the target path is inside the task workspace root; prompts otherwise |
+| `execute` | `unix`, `python` | Always prompts |
+| _undeclared_ | MCP tools and any third-party tool that does not declare a category | Treated as `execute` and prompts |
+
+The rules below always take precedence over these defaults — an `allow` rule lets an `execute` tool run without a prompt, and a `deny` rule blocks even a `read` tool.
+
 ### Permission Sources and Priority
 
 Permission rules come from three sources, listed from lowest to highest priority:

--- a/internal/agent/confirmation.go
+++ b/internal/agent/confirmation.go
@@ -75,6 +75,13 @@ func NewConfirmationManager(allow []string, ruleSets []config.PermissionRuleSet,
 }
 
 func (cm *ConfirmationManager) Confirm(action string) (bool, error) {
+	return cm.ConfirmWithDefault(action, false)
+}
+
+// ConfirmWithDefault resolves an action against the ask/allow/deny rules. When
+// no rule matches, autoAllow decides the fallback: true allows without
+// prompting (e.g. read tools, in-workspace writes), false prompts the user.
+func (cm *ConfirmationManager) ConfirmWithDefault(action string, autoAllow bool) (bool, error) {
 	if action == "" {
 		return true, nil
 	}
@@ -90,6 +97,10 @@ func (cm *ConfirmationManager) Confirm(action string) (bool, error) {
 	if allowed, matched := cm.resolveAllowDeny(action); matched {
 		cm.decisions[action] = allowed
 		return allowed, nil
+	}
+
+	if autoAllow {
+		return true, nil
 	}
 
 	return cm.confirmAndRemember(action)

--- a/internal/agent/confirmation_test.go
+++ b/internal/agent/confirmation_test.go
@@ -1,6 +1,56 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/laszukdawid/terminal-agent/internal/config"
+)
+
+func TestConfirmWithDefaultAutoAllowFallback(t *testing.T) {
+	manager := NewConfirmationManager(nil, nil, nil, nil)
+
+	allowed, err := manager.ConfirmWithDefault("read(path=\"/tmp/file\")", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("autoAllow fallback should allow without prompting")
+	}
+}
+
+func TestConfirmWithDefaultGatesWhenNotAutoAllowed(t *testing.T) {
+	manager := NewConfirmationManager(nil, nil, nil, nil)
+
+	// A nil confirm callback errors when a prompt is required, which is how we
+	// detect that the action was gated rather than auto-allowed.
+	if _, err := manager.ConfirmWithDefault("unix(\"rm -rf /\")", false); err == nil {
+		t.Fatal("expected a prompt when not auto-allowed and no rule matches")
+	}
+}
+
+func TestConfirmWithDefaultDenyBeatsAutoAllow(t *testing.T) {
+	manager := NewConfirmationManager(nil, []config.PermissionRuleSet{{
+		Permissions: config.Permissions{Deny: []string{"file_edit(path=\"*\")"}},
+	}}, nil, nil)
+
+	allowed, err := manager.ConfirmWithDefault("file_edit(path=\"/repo/x\")", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Fatal("deny rule must override autoAllow")
+	}
+}
+
+func TestConfirmWithDefaultAskBeatsAutoAllow(t *testing.T) {
+	manager := NewConfirmationManager(nil, []config.PermissionRuleSet{{
+		Permissions: config.Permissions{Ask: []string{"file_edit(path=\"*\")"}},
+	}}, nil, nil)
+
+	if _, err := manager.ConfirmWithDefault("file_edit(path=\"/repo/x\")", true); err == nil {
+		t.Fatal("ask rule must force a prompt even when autoAllow is true")
+	}
+}
 
 func TestBuildActionString(t *testing.T) {
 	action := BuildActionString("unix", map[string]any{

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -266,7 +266,7 @@ func (a *Agent) handleTaskToolResponse(ctx context.Context, logger *zap.SugaredL
 		return TaskRunResult{}, false, nil
 	}
 
-	allowed, err := run.confirmTool(response)
+	allowed, err := run.confirmTool(tool, response)
 	if err != nil {
 		logger.Errorw("Tool confirmation failed", "tool", response.ToolName, "error", err)
 		return TaskRunResult{}, false, fmt.Errorf("tool confirmation failed: %w", err)
@@ -339,11 +339,27 @@ func (a *Agent) finalizeTaskRun(ctx context.Context, run *taskExecutionState) (T
 	return TaskRunResult{Response: response, RawOutput: rawOutput.Output, RawOutputTool: rawOutput.ToolName}, nil
 }
 
-func (r *taskExecutionState) confirmTool(response connector.LlmResponseWithTools) (bool, error) {
-	if !requiresConfirmation(response.ToolName) {
-		return true, nil
+func (r *taskExecutionState) confirmTool(tool tools.Tool, response connector.LlmResponseWithTools) (bool, error) {
+	autoAllow := r.autoAllowsTool(tool, response.ToolInput)
+	return r.confirmations.ConfirmWithDefault(BuildActionString(response.ToolName, response.ToolInput), autoAllow)
+}
+
+// autoAllowsTool reports the default confirmation decision for a tool when no
+// explicit allow/deny/ask rule matches: read tools and in-workspace writes run
+// without prompting; arbitrary execution and undeclared tools are gated.
+func (r *taskExecutionState) autoAllowsTool(tool tools.Tool, input map[string]any) bool {
+	switch permissionCategoryFor(tool) {
+	case tools.PermissionRead:
+		return true
+	case tools.PermissionWrite:
+		path, _ := input["path"].(string)
+		return tools.PathWithinRoot(path, tools.ToolExecutionContext{
+			RootDir:    r.state.Dirs.RootDir,
+			CurrentDir: r.state.Dirs.CurrentDir,
+		})
+	default:
+		return false
 	}
-	return r.confirmations.Confirm(BuildActionString(response.ToolName, response.ToolInput))
 }
 
 func (r *taskExecutionState) recordThought(thought string) {
@@ -866,13 +882,14 @@ func toolInputRequestsFinal(input map[string]any) bool {
 	return taskToolInputRequestsFinal(input)
 }
 
-func requiresConfirmation(toolName string) bool {
-	switch toolName {
-	case tools.ToolNameUnix, tools.ToolNameFileEdit, tools.ToolNamePython:
-		return true
-	default:
-		return false
+// permissionCategoryFor returns a tool's declared permission category, treating
+// tools that do not declare one (e.g. MCP tools) as PermissionExecute so they
+// are gated by default.
+func permissionCategoryFor(tool tools.Tool) tools.PermissionCategory {
+	if categorized, ok := tool.(tools.CategorizedTool); ok {
+		return categorized.PermissionCategory()
 	}
+	return tools.PermissionExecute
 }
 
 type askUserTool struct {
@@ -902,6 +919,10 @@ func NewAskUserTool(interaction TaskInteraction) *askUserTool {
 
 func (t *askUserTool) Name() string {
 	return t.name
+}
+
+func (t *askUserTool) PermissionCategory() tools.PermissionCategory {
+	return tools.PermissionRead
 }
 
 func (t *askUserTool) Description() string {
@@ -963,6 +984,10 @@ func NewFinalAnswerTool() *finalAnswerTool {
 
 func (t *finalAnswerTool) Name() string {
 	return t.name
+}
+
+func (t *finalAnswerTool) PermissionCategory() tools.PermissionCategory {
+	return tools.PermissionRead
 }
 
 func (t *finalAnswerTool) Description() string {

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -24,21 +24,29 @@ type fixedOutputTool struct {
 	output string
 }
 
-func (t *fixedOutputTool) Name() string                             { return t.name }
-func (t *fixedOutputTool) Description() string                      { return "" }
-func (t *fixedOutputTool) InputSchema() map[string]any              { return map[string]any{} }
-func (t *fixedOutputTool) HelpText() string                         { return "" }
-func (t *fixedOutputTool) RunSchema(map[string]any) (string, error) { return t.output, nil }
-func (t *fixedOutputTool) Run(*string) (string, error)              { return t.output, nil }
+func (t *fixedOutputTool) Name() string                                 { return t.name }
+func (t *fixedOutputTool) PermissionCategory() tools.PermissionCategory { return tools.PermissionRead }
+func (t *fixedOutputTool) Description() string                          { return "" }
+func (t *fixedOutputTool) InputSchema() map[string]any                  { return map[string]any{} }
+func (t *fixedOutputTool) HelpText() string                             { return "" }
+func (t *fixedOutputTool) RunSchema(map[string]any) (string, error)     { return t.output, nil }
+func (t *fixedOutputTool) Run(*string) (string, error)                  { return t.output, nil }
 
 type schemaOutputTool struct {
-	name   string
-	output string
-	schema map[string]any
-	inputs []map[string]any
+	name     string
+	output   string
+	schema   map[string]any
+	inputs   []map[string]any
+	category tools.PermissionCategory
 }
 
-func (t *schemaOutputTool) Name() string                { return t.name }
+func (t *schemaOutputTool) Name() string { return t.name }
+func (t *schemaOutputTool) PermissionCategory() tools.PermissionCategory {
+	if t.category != "" {
+		return t.category
+	}
+	return tools.PermissionRead
+}
 func (t *schemaOutputTool) Description() string         { return "" }
 func (t *schemaOutputTool) InputSchema() map[string]any { return t.schema }
 func (t *schemaOutputTool) HelpText() string            { return "" }
@@ -55,7 +63,10 @@ type sequentialOutputTool struct {
 	inputs  []map[string]any
 }
 
-func (t *sequentialOutputTool) Name() string                { return t.name }
+func (t *sequentialOutputTool) Name() string { return t.name }
+func (t *sequentialOutputTool) PermissionCategory() tools.PermissionCategory {
+	return tools.PermissionRead
+}
 func (t *sequentialOutputTool) Description() string         { return "" }
 func (t *sequentialOutputTool) InputSchema() map[string]any { return t.schema }
 func (t *sequentialOutputTool) HelpText() string            { return "" }
@@ -231,6 +242,55 @@ func (i *fakeTaskInteraction) Clarify(req TaskClarificationRequest) (string, err
 	return i.answer, nil
 }
 
+// uncategorizedStubTool stands in for an MCP/third-party tool that does not
+// declare a permission category, so it must default to gated.
+type uncategorizedStubTool struct{}
+
+func (uncategorizedStubTool) RunSchema(map[string]any) (string, error) { return "", nil }
+func (uncategorizedStubTool) Run(*string) (string, error)              { return "", nil }
+func (uncategorizedStubTool) Name() string                             { return "mcp_thing" }
+func (uncategorizedStubTool) Description() string                      { return "external tool" }
+func (uncategorizedStubTool) InputSchema() map[string]any              { return map[string]any{} }
+func (uncategorizedStubTool) HelpText() string                         { return "" }
+
+func TestConfirmToolByCategory(t *testing.T) {
+	cases := []struct {
+		name       string
+		tool       tools.Tool
+		input      map[string]any
+		wantPrompt bool
+	}{
+		{"read never prompts", tools.NewReadTool("/repo"), map[string]any{"path": "x"}, false},
+		{"write inside root", tools.NewFileEditTool("/repo"), map[string]any{"path": "notes.txt", "operation": "write"}, false},
+		{"write outside root", tools.NewFileEditTool("/repo"), map[string]any{"path": "../escape.txt", "operation": "write"}, true},
+		{"execute always prompts", tools.NewUnixTool(nil), map[string]any{"command": "ls"}, true},
+		{"undeclared tool gated", uncategorizedStubTool{}, map[string]any{}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			interaction := &fakeTaskInteraction{decision: TaskConfirmationDecision{Allowed: true}}
+			requester := taskUserConfirmationRequester{interaction: interaction}
+			run := &taskExecutionState{
+				state:         &TaskState{Dirs: TaskDirs{RootDir: "/repo", CurrentDir: "/repo"}},
+				confirmations: NewConfirmationManager(nil, nil, requester.RequestUserConfirmation, nil),
+			}
+			response := connector.LlmResponseWithTools{ToolName: tc.tool.Name(), ToolInput: tc.input}
+
+			allowed, err := run.confirmTool(tc.tool, response)
+			if err != nil {
+				t.Fatalf("confirmTool error: %v", err)
+			}
+			if !allowed {
+				t.Fatal("expected allow (interaction approves)")
+			}
+			if gotPrompt := len(interaction.confirmations) > 0; gotPrompt != tc.wantPrompt {
+				t.Fatalf("prompted = %v, want %v", gotPrompt, tc.wantPrompt)
+			}
+		})
+	}
+}
+
 func TestFinalizeSummaryUsesRenderedTemplate(t *testing.T) {
 	conn := &summaryCaptureConnector{}
 	sysPrompt := "task system prompt"
@@ -318,8 +378,9 @@ func TestTaskUsesInjectedConfirmationInteraction(t *testing.T) {
 	rootDir := t.TempDir()
 	interaction := &fakeTaskInteraction{decision: TaskConfirmationDecision{Allowed: true, Remember: true}}
 	unixTool := &schemaOutputTool{
-		name:   tools.ToolNameUnix,
-		output: "status output",
+		name:     tools.ToolNameUnix,
+		category: tools.PermissionExecute,
+		output:   "status output",
 		schema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/file_edit.go
+++ b/internal/tools/file_edit.go
@@ -65,6 +65,10 @@ func (t *FileEditTool) Name() string {
 	return t.name
 }
 
+func (t *FileEditTool) PermissionCategory() PermissionCategory {
+	return PermissionWrite
+}
+
 func (t *FileEditTool) Description() string {
 	return t.description
 }

--- a/internal/tools/file_search.go
+++ b/internal/tools/file_search.go
@@ -75,6 +75,10 @@ func (t *FileSearchTool) Name() string {
 	return t.name
 }
 
+func (t *FileSearchTool) PermissionCategory() PermissionCategory {
+	return PermissionRead
+}
+
 func (t *FileSearchTool) Description() string {
 	return t.description
 }

--- a/internal/tools/path.go
+++ b/internal/tools/path.go
@@ -90,6 +90,13 @@ func resolveRootInContext(root string, ctx ToolExecutionContext, fallbackDir str
 	return resolvePathInContext(root, normalizedCtx, fallbackDir)
 }
 
+// PathWithinRoot reports whether path resolves to a location inside the
+// context's workspace root. An empty or unresolvable path returns false.
+func PathWithinRoot(path string, ctx ToolExecutionContext) bool {
+	_, err := resolvePathInContext(path, ctx, ctx.CurrentDir)
+	return err == nil
+}
+
 func resolvePath(path string, workDir string) (string, error) {
 	return resolvePathInContext(path, ToolExecutionContext{RootDir: workDir, CurrentDir: workDir}, workDir)
 }

--- a/internal/tools/python.go
+++ b/internal/tools/python.go
@@ -82,6 +82,10 @@ func (t *PythonTool) Name() string {
 	return t.name
 }
 
+func (t *PythonTool) PermissionCategory() PermissionCategory {
+	return PermissionExecute
+}
+
 func (t *PythonTool) Description() string {
 	return t.description
 }

--- a/internal/tools/read.go
+++ b/internal/tools/read.go
@@ -55,6 +55,10 @@ func (t *ReadTool) Name() string {
 	return t.name
 }
 
+func (t *ReadTool) PermissionCategory() PermissionCategory {
+	return PermissionRead
+}
+
 func (t *ReadTool) Description() string {
 	return t.description
 }

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -34,6 +34,22 @@ type AvailabilityAwareTool interface {
 	IsAvailable() bool
 }
 
+// PermissionCategory describes a tool's blast radius for confirmation policy.
+type PermissionCategory string
+
+const (
+	PermissionRead    PermissionCategory = "read"
+	PermissionWrite   PermissionCategory = "write"
+	PermissionExecute PermissionCategory = "execute"
+)
+
+// CategorizedTool lets a tool declare its permission category. Tools that do
+// not implement it are treated as PermissionExecute (gated).
+type CategorizedTool interface {
+	Tool
+	PermissionCategory() PermissionCategory
+}
+
 type ToolExecutionContext struct {
 	RootDir    string
 	CurrentDir string

--- a/internal/tools/unix.go
+++ b/internal/tools/unix.go
@@ -115,6 +115,10 @@ func (u *UnixTool) Name() string {
 	return u.name
 }
 
+func (u *UnixTool) PermissionCategory() PermissionCategory {
+	return PermissionExecute
+}
+
 func (u *UnixTool) Description() string {
 	return u.description
 }

--- a/internal/tools/websearch.go
+++ b/internal/tools/websearch.go
@@ -102,6 +102,10 @@ func (w *WebsearchTool) Name() string {
 	return w.name
 }
 
+func (w *WebsearchTool) PermissionCategory() PermissionCategory {
+	return PermissionRead
+}
+
 func (w *WebsearchTool) Description() string {
 	return w.description
 }


### PR DESCRIPTION
## Summary

Replaces the hardcoded `requiresConfirmation` switch in the task agent with a per-tool **permission category** that drives the default confirmation decision when no `allow`/`deny`/`ask` rule matches. The safety axis is *bounded vs arbitrary*, not read vs write.

Motivation:
- **Friction:** `file_edit` always prompted, even though it's bounded — its path/operation are visible up front and `ensureWithinRoot` already confines it to the workspace root.
- **Silent-execution hole:** the old `default: false` branch meant MCP tools (and any future tool) executed with **no** confirmation.

## Behavior (default when no rule matches)

| Category | Tools | Default |
| --- | --- | --- |
| `read` | `read`, `file_search`, `websearch`, `ask_user`, `final_answer` | never prompts |
| `write` | `file_edit` | no prompt when target is inside workspace root; prompts otherwise |
| `execute` | `unix`, `python` | always prompts |
| _undeclared_ | MCP / third-party tools | treated as `execute`, gated |

Tools self-declare via the optional `tools.CategorizedTool` interface (mirrors the existing `AvailabilityAwareTool`/`ContextualTool` pattern). Not implementing it ⇒ `execute` ⇒ gated.

## What's preserved

The `allow`/`deny`/`ask` rule engine is **unchanged** and remains the override layer. `ConfirmWithDefault` only changes the *fallback* when no rule matches (auto-allow vs prompt): `ask` still prompts, `deny` still beats `allow` at equal-or-higher priority, decisions are still cached, and `yes!`/`no!` memory is untouched.

## Changes

- `internal/tools/types.go` — `PermissionCategory` + `CategorizedTool` interface.
- Builtin tools declare their category; `internal/tools/path.go` exports `PathWithinRoot` (reuses `ensureWithinRoot`).
- `internal/agent/confirmation.go` — `ConfirmWithDefault(action, autoAllow)`; `Confirm` delegates with `false`.
- `internal/agent/task.go` — `requiresConfirmation` → `permissionCategoryFor`; `confirmTool` derives the per-category default.
- Docs: `AGENTS.md` permissions section + `docs/configuration.md` category table.

## Testing

- New unit tests: `ConfirmWithDefault` fallback + deny/ask precedence; table-driven `TestConfirmToolByCategory` covering read / write-in-root / write-outside / execute / undeclared-tool gating.
- `go build ./...`, full `go test ./...`, `go vet`, `gofmt -l` — all clean.
- Snyk code scan on `internal/agent` and `internal/tools` — 0 issues.