### PR TITLE
Show provider readiness in GUI settings

### DIFF
--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -210,7 +210,7 @@ tasks:
     desc: Set the provider to google
     cmds:
       - go run cmd/agent/main.go config set provider google
-      - go run cmd/agent/main.go config set model gemini-2.0-flash-lite
+      - go run cmd/agent/main.go config set model gemini-3.1-flash-lite
   
   run:set:ollama:
     desc: Set the provider to ollama
@@ -361,7 +361,7 @@ tasks:
     vars:
       Q: "What command shows disk usage in human readable form?"
       PROVIDER: "google"
-      MODEL: "gemini-2.0-flash-lite"
+      MODEL: "gemini-3.1-flash-lite"
     cmds:
       - task: test:model:ask
         vars:
@@ -414,7 +414,7 @@ tasks:
     vars:
       Q: "List all files in home directory"
       PROVIDER: "google"
-      MODEL: "gemini-2.0-flash-lite"
+      MODEL: "gemini-3.1-flash-lite"
     cmds:
       - task: test:model:task
         vars:

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -106,7 +106,7 @@ agent config set model anthropic.claude-3-haiku-20240307-v1:0
 ### Google
 ```sh
 agent config set provider google
-agent config set model gemini-2.0-flash-lite
+agent config set model gemini-3.1-flash-lite
 ```
 
 ### Ollama

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,7 +184,7 @@ Stored credentials are managed with the `agent auth` command and take effect aut
 |----------|---------------------|-----------|-------------|
 | OpenAI | `OPENAI_API_KEY` | supported | API key or stored credential for OpenAI services |
 | Anthropic | `ANTHROPIC_API_KEY` | — | API key for Anthropic Claude models |
-| Google | `GOOGLE_API_KEY` | — | API key for Google AI (Gemini) |
+| Google | `GEMINI_API_KEY` | — | API key for Google AI (Gemini) |
 | Xiaomi MiMo | `MIMO_API_KEY` | — | API key for Xiaomi MiMo models |
 | Mistral | `MISTRAL_API_KEY` | — | API key for Mistral AI models |
 | AWS Bedrock | AWS credentials | — | Standard AWS credential configuration |
@@ -227,7 +227,9 @@ mkdir -p ~/.local/share/yzma/lib
 export YZMA_LIB=$HOME/.local/share/yzma/lib
 ```
 
-For persistent configuration, add this to your shell profile (`.bashrc`, `.zshrc`, etc.).
+For persistent CLI configuration, add this to your shell profile (`.bashrc`, `.zshrc`, etc.).
+Desktop-launched GUI processes usually do not source shell startup files, so variables set only there may not be visible to `agent-gui`.
+If the GUI reports a provider key as unavailable, export it through your desktop/session environment or start `agent-gui` from a shell that already has the variable.
 
 ## Model Context Protocol (MCP)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,10 +93,13 @@ export OPENAI_API_KEY=your_api_key_here
 export ANTHROPIC_API_KEY=your_api_key_here
 
 # For Google
-export GOOGLE_API_KEY=your_api_key_here
+export GEMINI_API_KEY=your_api_key_here
 
 # For Amazon Bedrock, configure your AWS credentials as usual
 ```
+
+If you use the popup GUI from a desktop launcher or global shortcut, remember that it may not inherit variables from shell startup files like `~/.bashrc`.
+The Settings dialog reports whether provider variables such as `MIMO_API_KEY` are visible to the GUI process.
 
 If you want to use the direct local `llama` provider instead of an API-backed provider:
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -203,17 +203,17 @@ agent config set model claude-3-5-sonnet-latest
 2. Generate an API key
 3. Set the key as an environment variable:
    ```sh
-   export GOOGLE_API_KEY=your_api_key_here
+   export GEMINI_API_KEY=your_api_key_here
    ```
 
 **Configuration:**
 ```sh
 agent config set provider google
-agent config set model gemini-2.0-flash-lite
+agent config set model gemini-3.1-flash-lite
 ```
 
 **Recommended Models:**
-- `gemini-2.0-flash-lite` - Fast response times
+- `gemini-3.1-flash-lite` - Fast response times
 - `gemini-2.0-pro` - More capable model
 
 **Special Features:**

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -82,7 +82,7 @@ func NewDefaultConfig() *config {
 		Providers: map[string]string{
 			"anthropic": "claude-3-5-haiku-latest",
 			"bedrock":   "anthropic.claude-3-haiku-20240307-v1:0",
-			"google":    "gemini-2.0-flash-lite",
+			"google":    "gemini-3.1-flash-lite",
 			"llama":     "llama3.2",
 			"mimo":      "mimo-v2.5-pro",
 			"mistral":   "mistral-small-latest",

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -77,7 +77,7 @@ func TestLoadConfig(t *testing.T) {
 		assert.Equal(t, "mimo-v2.5-pro", config.Providers["mimo"])
 		assert.Equal(t, "mistral-small-latest", config.Providers["mistral"])
 		assert.Equal(t, "gpt-4o-mini", config.Providers["openai"])
-		assert.Equal(t, "gemini-2.0-flash-lite", config.Providers["google"])
+		assert.Equal(t, "gemini-3.1-flash-lite", config.Providers["google"])
 		assert.Equal(t, "llama3.2", config.Providers["ollama"])
 		assert.Empty(t, config.GetLlamaModels())
 

--- a/internal/connector/google.go
+++ b/internal/connector/google.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	GoogleProvider    = "google"
-	Gemini20FlashLite = "gemini-2.0-flash-lite"
+	Gemini31FlashLite = "gemini-3.1-flash-lite"
 )
 
 type GoogleConnector struct {
@@ -30,7 +30,7 @@ func NewGoogleConnector(modelID *string) *GoogleConnector {
 	logger.Debug("NewGoogleConnector")
 
 	if modelID == nil || *modelID == "" {
-		model := Gemini20FlashLite
+		model := Gemini31FlashLite
 		modelID = &model
 	}
 

--- a/internal/connector/google_test.go
+++ b/internal/connector/google_test.go
@@ -207,7 +207,7 @@ func TestConvertToGenaiSchema(t *testing.T) {
 
 func TestNewGoogleConnector(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "test")
-	modelID := "gemini-2.0-flash-lite"
+	modelID := "gemini-3.1-flash-lite"
 
 	connector := NewGoogleConnector(&modelID)
 
@@ -222,7 +222,7 @@ func TestNewGoogleConnector(t *testing.T) {
 
 func TestNewGoogleConnectorNoKey(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "")
-	modelID := "gemini-2.0-flash-lite"
+	modelID := "gemini-3.1-flash-lite"
 
 	connector := NewGoogleConnector(&modelID)
 
@@ -239,7 +239,7 @@ func TestNewGoogleConnectorNoModelID(t *testing.T) {
 		t.Fatal("Expected connector to be created, got nil")
 	}
 
-	if connector.modelID != "gemini-2.0-flash-lite" {
-		t.Errorf("Expected modelID to be gemini-2.0-flash-lite, got %s", connector.modelID)
+	if connector.modelID != "gemini-3.1-flash-lite" {
+		t.Errorf("Expected modelID to be gemini-3.1-flash-lite, got %s", connector.modelID)
 	}
 }

--- a/internal/connector/providers.go
+++ b/internal/connector/providers.go
@@ -16,7 +16,7 @@ var providerRegistry = []ProviderInfo{
 	{Name: AnthropicProvider, DefaultModel: DefaultAnthropicModel},
 	// BedrockModelID and ChatModel are named string types, hence the conversions.
 	{Name: BedrockProvider, DefaultModel: string(ClaudeHaiku)},
-	{Name: GoogleProvider, DefaultModel: Gemini20FlashLite},
+	{Name: GoogleProvider, DefaultModel: Gemini31FlashLite},
 	{Name: LlamaProvider, DefaultModel: DefaultLlamaModel},
 	{Name: MiMoProvider, DefaultModel: DefaultMiMoModel},
 	{Name: MistralProvider, DefaultModel: DefaultMistralModel},

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -71,6 +71,74 @@ type readOnlyEntry struct {
 	widget.Entry
 }
 
+type providerStatusIcon struct {
+	widget.BaseWidget
+	canvas  fyne.Canvas
+	icon    *canvas.Text
+	message string
+	popup   *widget.PopUp
+}
+
+func newProviderStatusIcon(c fyne.Canvas) *providerStatusIcon {
+	status := &providerStatusIcon{
+		canvas: c,
+		icon:   canvas.NewText("", theme.Color(theme.ColorNameForeground)),
+	}
+	status.icon.TextSize = theme.TextSize() + 1
+	status.icon.TextStyle = fyne.TextStyle{Bold: true}
+	status.ExtendBaseWidget(status)
+	return status
+}
+
+func (s *providerStatusIcon) setStatus(status providerReadiness) {
+	s.message = ""
+	if status.Message == "" {
+		s.icon.Text = ""
+	} else if status.Available {
+		s.icon.Text = "✓"
+		s.icon.Color = theme.Color(theme.ColorNameSuccess)
+	} else {
+		s.icon.Text = "✕"
+		s.icon.Color = theme.Color(theme.ColorNameError)
+		s.message = status.Message
+	}
+	if s.popup != nil {
+		s.popup.Hide()
+		s.popup = nil
+	}
+	s.icon.Refresh()
+	s.Refresh()
+}
+
+func (s *providerStatusIcon) CreateRenderer() fyne.WidgetRenderer {
+	return widget.NewSimpleRenderer(s.icon)
+}
+
+func (s *providerStatusIcon) MouseIn(e *desktop.MouseEvent) {
+	if s.message == "" || s.canvas == nil {
+		return
+	}
+	label := widget.NewLabel(s.message)
+	label.Wrapping = fyne.TextWrapWord
+	content := container.NewPadded(label)
+	s.popup = widget.NewPopUp(content, s.canvas)
+	s.popup.Resize(fyne.NewSize(360, content.MinSize().Height))
+	pos := s.Position().AddXY(s.Size().Width+8, 0)
+	if e != nil {
+		pos = e.AbsolutePosition.AddXY(12, 12)
+	}
+	s.popup.ShowAtPosition(pos)
+}
+
+func (s *providerStatusIcon) MouseMoved(*desktop.MouseEvent) {}
+
+func (s *providerStatusIcon) MouseOut() {
+	if s.popup != nil {
+		s.popup.Hide()
+		s.popup = nil
+	}
+}
+
 func newPopupEntry(app fyne.App) *popupEntry {
 	entry := &popupEntry{app: app}
 	entry.ExtendBaseWidget(entry)
@@ -308,12 +376,12 @@ func (p *popupWindow) showSettingsDialog(initialProvider, initialModel string, o
 		l.TextStyle = fyne.TextStyle{Italic: true}
 		return l
 	}
-	setupHint := newHint()
 	modelHint := newHint()
+	providerStatus := newProviderStatusIcon(p.window.Canvas())
 
 	updateHints := func(provider string) {
 		provider = strings.TrimSpace(provider)
-		setupHint.SetText(providerSetupHint(provider))
+		providerStatus.setStatus(providerReadinessStatus(provider))
 		if def := connector.DefaultModelFor(provider); def != "" {
 			modelHint.SetText("Default model: " + def)
 		} else {
@@ -324,14 +392,14 @@ func (p *popupWindow) showSettingsDialog(initialProvider, initialModel string, o
 	providerInput := newProviderEntry(initialProvider, updateHints)
 
 	providerLabel := widget.NewLabelWithStyle("Provider", fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
+	providerLabelBox := container.NewHBox(providerLabel, providerStatus)
 	modelLabel := widget.NewLabelWithStyle("Model", fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
 
 	// A single FormLayout grid keeps the Provider and Model labels and inputs
 	// aligned, and makes both inputs start at the same x with the same width.
 	// Hint rows use an empty label cell so each hint aligns under its input.
 	form := container.New(layout.NewFormLayout(),
-		providerLabel, providerInput,
-		widget.NewLabel(""), setupHint,
+		providerLabelBox, providerInput,
 		modelLabel, modelEntry,
 		widget.NewLabel(""), modelHint,
 	)

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -25,8 +25,6 @@ const (
 	compactOutputHeight   float32 = 110
 	statusMinWidth        float32 = 130
 	statusIndicatorSize   float32 = 18
-	providerStatusWidth   float32 = 28
-	providerStatusHeight  float32 = 24
 	maxVisibleOutputLines         = 5
 )
 
@@ -113,35 +111,14 @@ func (s *providerStatusIcon) setStatus(status providerReadiness) {
 }
 
 func (s *providerStatusIcon) CreateRenderer() fyne.WidgetRenderer {
-	return &providerStatusIconRenderer{icon: s.icon}
-}
-
-type providerStatusIconRenderer struct {
-	icon *canvas.Text
-}
-
-func (r *providerStatusIconRenderer) Destroy() {}
-
-func (r *providerStatusIconRenderer) Layout(size fyne.Size) {
-	iconSize := r.icon.MinSize()
-	r.icon.Resize(iconSize)
-	r.icon.Move(fyne.NewPos((size.Width-iconSize.Width)/2, (size.Height-iconSize.Height)/2))
-}
-
-func (r *providerStatusIconRenderer) MinSize() fyne.Size {
-	return fyne.NewSize(providerStatusWidth, providerStatusHeight)
-}
-
-func (r *providerStatusIconRenderer) Objects() []fyne.CanvasObject {
-	return []fyne.CanvasObject{r.icon}
-}
-
-func (r *providerStatusIconRenderer) Refresh() {
-	r.icon.Refresh()
+	return widget.NewSimpleRenderer(s.icon)
 }
 
 func (s *providerStatusIcon) MouseIn(e *desktop.MouseEvent) {
 	if s.message == "" || s.canvas == nil {
+		return
+	}
+	if s.popup != nil {
 		return
 	}
 	label := widget.NewLabel(s.message)
@@ -151,7 +128,7 @@ func (s *providerStatusIcon) MouseIn(e *desktop.MouseEvent) {
 	s.popup.Resize(fyne.NewSize(360, content.MinSize().Height))
 	pos := s.Position().AddXY(s.Size().Width+8, 0)
 	if e != nil {
-		pos = e.AbsolutePosition.AddXY(12, 12)
+		pos = e.AbsolutePosition.AddXY(28, 28)
 	}
 	s.popup.ShowAtPosition(pos)
 }

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -25,6 +25,8 @@ const (
 	compactOutputHeight   float32 = 110
 	statusMinWidth        float32 = 130
 	statusIndicatorSize   float32 = 18
+	providerStatusWidth   float32 = 28
+	providerStatusHeight  float32 = 24
 	maxVisibleOutputLines         = 5
 )
 
@@ -111,14 +113,35 @@ func (s *providerStatusIcon) setStatus(status providerReadiness) {
 }
 
 func (s *providerStatusIcon) CreateRenderer() fyne.WidgetRenderer {
-	return widget.NewSimpleRenderer(s.icon)
+	return &providerStatusIconRenderer{icon: s.icon}
+}
+
+type providerStatusIconRenderer struct {
+	icon *canvas.Text
+}
+
+func (r *providerStatusIconRenderer) Destroy() {}
+
+func (r *providerStatusIconRenderer) Layout(size fyne.Size) {
+	iconSize := r.icon.MinSize()
+	r.icon.Resize(iconSize)
+	r.icon.Move(fyne.NewPos((size.Width-iconSize.Width)/2, (size.Height-iconSize.Height)/2))
+}
+
+func (r *providerStatusIconRenderer) MinSize() fyne.Size {
+	return fyne.NewSize(providerStatusWidth, providerStatusHeight)
+}
+
+func (r *providerStatusIconRenderer) Objects() []fyne.CanvasObject {
+	return []fyne.CanvasObject{r.icon}
+}
+
+func (r *providerStatusIconRenderer) Refresh() {
+	r.icon.Refresh()
 }
 
 func (s *providerStatusIcon) MouseIn(e *desktop.MouseEvent) {
 	if s.message == "" || s.canvas == nil {
-		return
-	}
-	if s.popup != nil {
 		return
 	}
 	label := widget.NewLabel(s.message)
@@ -128,7 +151,7 @@ func (s *providerStatusIcon) MouseIn(e *desktop.MouseEvent) {
 	s.popup.Resize(fyne.NewSize(360, content.MinSize().Height))
 	pos := s.Position().AddXY(s.Size().Width+8, 0)
 	if e != nil {
-		pos = e.AbsolutePosition.AddXY(28, 28)
+		pos = e.AbsolutePosition.AddXY(12, 12)
 	}
 	s.popup.ShowAtPosition(pos)
 }

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -25,6 +25,8 @@ const (
 	compactOutputHeight   float32 = 110
 	statusMinWidth        float32 = 130
 	statusIndicatorSize   float32 = 18
+	providerStatusWidth   float32 = 28
+	providerStatusHeight  float32 = 24
 	maxVisibleOutputLines         = 5
 )
 
@@ -111,7 +113,31 @@ func (s *providerStatusIcon) setStatus(status providerReadiness) {
 }
 
 func (s *providerStatusIcon) CreateRenderer() fyne.WidgetRenderer {
-	return widget.NewSimpleRenderer(s.icon)
+	return &providerStatusIconRenderer{icon: s.icon}
+}
+
+type providerStatusIconRenderer struct {
+	icon *canvas.Text
+}
+
+func (r *providerStatusIconRenderer) Destroy() {}
+
+func (r *providerStatusIconRenderer) Layout(size fyne.Size) {
+	iconSize := r.icon.MinSize()
+	r.icon.Resize(iconSize)
+	r.icon.Move(fyne.NewPos((size.Width-iconSize.Width)/2, (size.Height-iconSize.Height)/2))
+}
+
+func (r *providerStatusIconRenderer) MinSize() fyne.Size {
+	return fyne.NewSize(providerStatusWidth, providerStatusHeight)
+}
+
+func (r *providerStatusIconRenderer) Objects() []fyne.CanvasObject {
+	return []fyne.CanvasObject{r.icon}
+}
+
+func (r *providerStatusIconRenderer) Refresh() {
+	r.icon.Refresh()
 }
 
 func (s *providerStatusIcon) MouseIn(e *desktop.MouseEvent) {

--- a/internal/gui/settings_validation.go
+++ b/internal/gui/settings_validation.go
@@ -63,6 +63,57 @@ func providerSetupHint(provider string) string {
 	return ""
 }
 
+type providerReadiness struct {
+	Available bool
+	Message   string
+}
+
+func providerReadinessStatus(provider string) providerReadiness {
+	switch provider {
+	case connector.OpenaiProvider:
+		if os.Getenv("OPENAI_API_KEY") != "" {
+			return providerReadiness{Available: true, Message: "Available: OPENAI_API_KEY is visible to the GUI process."}
+		}
+		status, err := auth.NewManager().Status(provider)
+		if err == nil && status.Configured {
+			return providerReadiness{Available: true, Message: "Available: stored OpenAI auth is configured."}
+		}
+		return providerReadiness{Message: "Unavailable: OPENAI_API_KEY is not visible to the GUI process, and no stored OpenAI auth is configured."}
+	case connector.AnthropicProvider:
+		return envProviderReadiness("Anthropic", "ANTHROPIC_API_KEY")
+	case connector.GoogleProvider:
+		return envProviderReadiness("Google", "GEMINI_API_KEY")
+	case connector.MistralProvider:
+		return envProviderReadiness("Mistral", "MISTRAL_API_KEY")
+	case connector.MiMoProvider:
+		return envProviderReadiness("MiMo", "MIMO_API_KEY")
+	case connector.LlamaProvider:
+		if os.Getenv("YZMA_LIB") != "" {
+			return providerReadiness{Available: true, Message: "Available: YZMA_LIB is visible to the GUI process."}
+		}
+		return providerReadiness{Message: "Unavailable: YZMA_LIB is not visible to the GUI process."}
+	case connector.OllamaProvider:
+		return providerReadiness{Available: true, Message: "Available: Ollama does not require an API key; OLLAMA_HOST is optional."}
+	case connector.BedrockProvider:
+		if os.Getenv("AWS_REGION") != "" {
+			return providerReadiness{Available: true, Message: "Check AWS credentials: AWS_REGION is visible; Bedrock uses the AWS SDK credential chain."}
+		}
+		return providerReadiness{Available: true, Message: "Check AWS credentials: Bedrock uses the AWS SDK credential chain and defaults AWS_REGION when unset."}
+	default:
+		if provider == "" {
+			return providerReadiness{}
+		}
+		return providerReadiness{Message: fmt.Sprintf("Unknown provider: %s", provider)}
+	}
+}
+
+func envProviderReadiness(displayName, envVar string) providerReadiness {
+	if os.Getenv(envVar) != "" {
+		return providerReadiness{Available: true, Message: fmt.Sprintf("Available: %s is visible to the GUI process.", envVar)}
+	}
+	return providerReadiness{Message: fmt.Sprintf("Unavailable: %s is not visible to the GUI process. %s requires it.", envVar, displayName)}
+}
+
 func explainRuntimeError(provider string, err error) string {
 	if err == nil {
 		return ""

--- a/internal/gui/settings_validation_test.go
+++ b/internal/gui/settings_validation_test.go
@@ -16,6 +16,28 @@ func TestProviderSetupHintMiMo(t *testing.T) {
 	assert.Contains(t, providerSetupHint(connector.MiMoProvider), "MIMO_API_KEY")
 }
 
+func TestProviderReadinessMiMoMissing(t *testing.T) {
+	t.Setenv("MIMO_API_KEY", "")
+
+	status := providerReadinessStatus(connector.MiMoProvider)
+
+	assert.False(t, status.Available)
+	assert.Contains(t, status.Message, "Unavailable")
+	assert.Contains(t, status.Message, "MIMO_API_KEY")
+	assert.Contains(t, status.Message, "GUI process")
+}
+
+func TestProviderReadinessMiMoAvailable(t *testing.T) {
+	t.Setenv("MIMO_API_KEY", "test-key")
+
+	status := providerReadinessStatus(connector.MiMoProvider)
+
+	assert.True(t, status.Available)
+	assert.Contains(t, status.Message, "Available")
+	assert.Contains(t, status.Message, "MIMO_API_KEY")
+	assert.Contains(t, status.Message, "GUI process")
+}
+
 // The Google hint must name the env var the connector actually reads
 // (GEMINI_API_KEY), not GOOGLE_API_KEY.
 func TestProviderSetupHintGoogle(t *testing.T) {
@@ -23,6 +45,23 @@ func TestProviderSetupHintGoogle(t *testing.T) {
 	hint := providerSetupHint(connector.GoogleProvider)
 	assert.Contains(t, hint, "GEMINI_API_KEY")
 	assert.NotContains(t, hint, "GOOGLE_API_KEY")
+}
+
+func TestProviderReadinessGoogleUsesGeminiAPIKey(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "")
+
+	status := providerReadinessStatus(connector.GoogleProvider)
+
+	assert.False(t, status.Available)
+	assert.Contains(t, status.Message, "GEMINI_API_KEY")
+	assert.NotContains(t, status.Message, "GOOGLE_API_KEY")
+}
+
+func TestProviderReadinessOllamaAvailable(t *testing.T) {
+	status := providerReadinessStatus(connector.OllamaProvider)
+
+	assert.True(t, status.Available)
+	assert.Contains(t, status.Message, "does not require an API key")
 }
 
 func TestFilterProviders(t *testing.T) {


### PR DESCRIPTION
## Summary
- show GUI provider readiness as a check/cross status icon with hover details for unavailable providers
- detect required provider environment variables from the GUI process environment
- update the default Gemini model to gemini-3.1-flash-lite and fix related docs/tests

## Tests
- go test ./internal/gui
- go test ./internal/connector ./internal/config