### PR TITLE
feat: stream task tool output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,13 @@ The repo is structured around the Go implementation of the binary (see `cmd/` an
 - The `llama` provider is a direct local runtime, not an HTTP API integration. It resolves model aliases from config and loads GGUF files plus a local llama.cpp shared library inside the current process.
 - Task execution is event-driven at the app layer. `internal/agent` orchestrates task steps and tool use, while confirmation and clarification transport is handled outside the agent core.
 
+Task tool output has two separate paths:
+
+- The tool's returned string is the captured result used by the agent for history, reasoning, summaries, and `final=true` direct output.
+- `tools.ToolExecutionContext.Output` is an optional live display sink for incremental user-facing output while a tool is still running. Tools may ignore it, but process-style tools such as `unix` and `python` should write stdout/stderr chunks there as soon as they are available while still returning the captured output at completion.
+
+For task events, live tool output is emitted as `EventOutputDelta` with `ToolName` and, when available, `ProcessID`. CLI printing is controlled by the task `--print` flag: `--print=false` suppresses both final output and live tool output, but the stream is still consumed so the task can continue. If live output delivery fails without task cancellation, the process should keep running and the app should emit `EventWarning` with the process id when the event channel is still usable; if the event path itself is broken, log the warning instead. Do not report display failures as command execution failures unless the context is canceled.
+
 Prompt and runtime behavior is also shared through this layer, with one important distinction:
 
 - `ask` and `chat` use ask-prompt resolution and may include memory/context features.
@@ -74,6 +81,8 @@ Taskfile commands will install Go dependencies automatically, but if you need to
 ## System Prompt Context
 
 Every request to an LLM includes a system prompt assembled from several layers (see `internal/agent/prompt.go`):
+
+Prompt-building code should prefer templates with named variables over positional string builders or `fmt.Sprintf` placeholders. Named fields such as `{{.OriginalQuery}}`, `{{.CurrentDir}}`, or `{{.History}}` make prompt changes easier to review and reduce accidental argument-order bugs. Keep template data structs small and specific to the prompt being rendered.
 
 1. **Header (`{{header}}`)** — `SystemPromptHeader()` injects dynamic system information:
    - Hostname, username, current time

--- a/docs/commands/task.md
+++ b/docs/commands/task.md
@@ -16,6 +16,10 @@ The agent will:
 
 The `task` command runs through an event-driven task execution path. The agent core decides what to do next, while the CLI owns terminal interaction for confirmations and clarification questions.
 
+When task tools run long-lived foreground commands, their stdout/stderr can be streamed to the terminal while the command is still running. This live stream is controlled by the same `--print` flag as the final response: with the default `--print=true`, output is printed as soon as it is available; with `--print=false`, live tool output and the final response are both suppressed while the task still consumes the event stream internally.
+
+If Terminal Agent cannot display live output but the process is still running, it emits a warning event that includes the process id when available. If the display event path itself is unavailable, the warning is written to logs instead.
+
 When the selected provider does not expose dependable native tool calling, Terminal Agent can fall back to a structured JSON action protocol. The direct local `llama` provider uses this path today, so `task` works there as well, although providers with native tool APIs are generally more reliable for complex workflows.
 
 ## Examples

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -143,6 +143,8 @@ To add a new tool:
 3. Update the `ToolProvider` to return your new tool
 4. Add documentation for your tool
 
+Tools that run long-lived processes or produce incremental output should also support `tools.ToolExecutionContext.Output` when they implement `ContextualTool` or `ContextAwareTool`. Write live user-facing chunks to `Output` as they become available, but still return the captured final result from `RunSchema*` so the task agent can reason over it. If the output sink implements `tools.ProcessesStartedWriter`, call `ProcessStarted(pid)` after the process starts so task events can include the process id in output and warning events.
+
 ## Documentation
 
 Documentation is written in Markdown and stored in the `docs/` directory. To update the documentation:

--- a/internal/agent/action_fallback.go
+++ b/internal/agent/action_fallback.go
@@ -1,0 +1,413 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/laszukdawid/terminal-agent/internal/connector"
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+)
+
+type taskActionFallbackResponse struct {
+	Action   string         `json:"action,omitempty"`
+	Type     string         `json:"type,omitempty"`
+	Tool     string         `json:"tool,omitempty"`
+	ToolName string         `json:"tool_name,omitempty"`
+	Input    map[string]any `json:"input,omitempty"`
+	Answer   string         `json:"answer,omitempty"`
+	Thought  string         `json:"thought,omitempty"`
+}
+
+const taskActionSystemPromptSuffix = `
+
+For the next response, return exactly one JSON object and no surrounding markdown or prose. Put any brief reasoning inside the "thought" field.`
+
+const taskActionPromptTemplateText = `Decide the next task step.
+
+Return exactly one JSON object. Do not return a schema, Markdown, or code fences.
+
+Valid response shapes:
+{"action":"tool","tool":"<tool name>","input":{...},"thought":"brief reason"}
+{"action":"final_answer","answer":"<final answer>","thought":"brief reason"}
+
+Rules:
+- Use "action", not "type".
+- Use "tool", not "tool_name".
+- The "input" field must contain the actual tool arguments for the chosen tool.
+- Do not return a JSON schema.
+- Use "final": true ONLY when raw output is definitely the final user-facing answer: concise, clean, readable, and requiring no interpretation.
+- If raw output needs interpretation, filtering, grouping, cleanup, explanation, or validation, do not set "final": true.
+
+Available tools:
+{{.Tools}}
+
+Task context:
+{{.Context}}
+
+Return valid JSON only.`
+
+const taskActionRetryPromptTemplateText = `Your previous response was invalid.
+
+Previous response:
+{{.PreviousResponse}}
+
+Problem:
+{{.Problem}}
+
+Return exactly one corrected JSON object and nothing else.
+
+Valid response shapes:
+{"action":"tool","tool":"<tool name>","input":{...},"thought":"brief reason"}
+{"action":"final_answer","answer":"<final answer>","thought":"brief reason"}
+
+Available tools:
+{{.Tools}}
+
+Task context:
+{{.Context}}
+
+Return valid JSON only.`
+
+var (
+	taskActionPromptTemplate      = template.Must(template.New("task_action_prompt").Parse(taskActionPromptTemplateText))
+	taskActionRetryPromptTemplate = template.Must(template.New("task_action_retry_prompt").Parse(taskActionRetryPromptTemplateText))
+)
+
+type taskActionPromptTemplateData struct {
+	Tools   string
+	Context string
+}
+
+type taskActionRetryPromptTemplateData struct {
+	PreviousResponse string
+	Problem          string
+	Tools            string
+	Context          string
+}
+
+func (a *Agent) queryTaskActionFallback(ctx context.Context, params *connector.QueryParams, taskTools map[string]tools.Tool) (connector.LlmResponseWithTools, error) {
+	fallbackParams := *params
+	fallbackParams.Messages = nil
+	fallbackParams.Stream = false
+	fallbackParams.OnStream = nil
+	fallbackSystemPrompt := buildTaskActionSystemPrompt(params.SysPrompt)
+	fallbackParams.SysPrompt = &fallbackSystemPrompt
+
+	var lastRaw string
+	var lastErr error
+	for attempt := 0; attempt < maxTaskActionFallbackRuns; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return connector.LlmResponseWithTools{}, err
+		}
+		prompt := a.buildTaskActionPrompt(params, taskTools, lastRaw, lastErr)
+		fallbackParams.UserPrompt = &prompt
+
+		raw, err := a.Connector.Query(ctx, &fallbackParams)
+		if err != nil {
+			return connector.LlmResponseWithTools{}, err
+		}
+
+		parsed, err := parseTaskActionFallbackResponse(raw)
+		if err != nil {
+			lastRaw = raw
+			lastErr = err
+			continue
+		}
+
+		response, err := buildTaskActionResponse(parsed)
+		if err != nil {
+			lastRaw = raw
+			lastErr = err
+			continue
+		}
+
+		return response, nil
+	}
+
+	return connector.LlmResponseWithTools{}, fmt.Errorf("task fallback produced invalid action after %d attempts: %w", maxTaskActionFallbackRuns, lastErr)
+}
+
+func buildTaskActionSystemPrompt(base *string) string {
+	if strings.TrimSpace(*base) == "" {
+		return strings.TrimSpace(taskActionSystemPromptSuffix)
+	}
+	return strings.TrimSpace(*base) + taskActionSystemPromptSuffix
+}
+
+func buildTaskActionResponse(parsed taskActionFallbackResponse) (connector.LlmResponseWithTools, error) {
+	response := connector.LlmResponseWithTools{Response: strings.TrimSpace(parsed.Thought)}
+	action := parsed.normalizedAction()
+	if action == "final_answer" {
+		response.ToolUse = true
+		response.ToolName = ToolNameFinalAnswer
+		response.ToolInput = map[string]any{"answer": strings.TrimSpace(parsed.Answer)}
+		return response, nil
+	}
+	if action != "tool" {
+		return connector.LlmResponseWithTools{}, fmt.Errorf("task fallback response has invalid action %q", action)
+	}
+
+	toolName := parsed.normalizedToolName()
+	if toolName == "" {
+		return connector.LlmResponseWithTools{}, fmt.Errorf("task fallback response is missing tool name")
+	}
+	if parsed.Input == nil {
+		parsed.Input = map[string]any{}
+	}
+
+	response.ToolUse = true
+	response.ToolName = toolName
+	response.ToolInput = parsed.Input
+	return response, nil
+}
+
+func (a *Agent) buildTaskActionPrompt(params *connector.QueryParams, taskTools map[string]tools.Tool, previousRaw string, previousErr error) string {
+	toolsText := formatTaskActionTools(taskTools)
+	contextText := formatTaskActionContext(params)
+	if previousErr == nil {
+		return renderTaskTemplate(taskActionPromptTemplate, taskActionPromptTemplateData{
+			Tools:   toolsText,
+			Context: contextText,
+		})
+	}
+	return renderTaskTemplate(
+		taskActionRetryPromptTemplate,
+		taskActionRetryPromptTemplateData{
+			PreviousResponse: TruncateString(strings.TrimSpace(previousRaw), 1200),
+			Problem:          previousErr.Error(),
+			Tools:            toolsText,
+			Context:          contextText,
+		},
+	)
+}
+
+func formatTaskActionTools(execTools map[string]tools.Tool) string {
+	names := make([]string, 0, len(execTools))
+	for name := range execTools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	entries := make([]string, 0, len(names))
+	for _, name := range names {
+		tool := execTools[name]
+		entry := fmt.Sprintf("- %s: %s", tool.Name(), tool.Description())
+		schemaHints := formatTaskActionSchemaHints(tool.InputSchema())
+		if schemaHints != "" {
+			entry += "\n" + schemaHints
+		}
+		entries = append(entries, entry)
+	}
+	return strings.Join(entries, "\n")
+}
+
+func formatTaskActionSchemaHints(schema map[string]any) string {
+	properties, ok := normalizeSchemaMap(schema["properties"])
+	if !ok || len(properties) == 0 {
+		return ""
+	}
+
+	required := make(map[string]bool)
+	for _, name := range schemaStringSlice(schema["required"]) {
+		required[name] = true
+	}
+
+	fieldNames := make([]string, 0, len(properties))
+	for name := range properties {
+		fieldNames = append(fieldNames, name)
+	}
+	sort.Strings(fieldNames)
+
+	lines := make([]string, 0, len(fieldNames)+2)
+	for _, fieldName := range fieldNames {
+		definition, ok := normalizeSchemaDefinition(properties[fieldName])
+		if !ok {
+			continue
+		}
+		line := fmt.Sprintf("  - %s (%s, %s)", fieldName, schemaFieldType(definition), requiredLabel(required[fieldName]))
+		if description, _ := definition["description"].(string); description != "" {
+			line += ": " + description
+		}
+		if enumValues := schemaStringSlice(definition["enum"]); len(enumValues) > 0 {
+			line += fmt.Sprintf(" Allowed values: %s.", strings.Join(enumValues, ", "))
+		}
+		lines = append(lines, line)
+	}
+
+	if requirementHint := formatTaskActionRequirementHints(schema); requirementHint != "" {
+		lines = append(lines, "  - requirement: "+requirementHint)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func schemaFieldType(definition map[string]any) string {
+	if typeName, _ := definition["type"].(string); typeName != "" {
+		return typeName
+	}
+	return "value"
+}
+
+func requiredLabel(required bool) string {
+	if required {
+		return "required"
+	}
+	return "optional"
+}
+
+func formatTaskActionRequirementHints(schema map[string]any) string {
+	branches := schemaAnySlice(schema["oneOf"])
+	label := "exactly one of"
+	if len(branches) == 0 {
+		branches = schemaAnySlice(schema["anyOf"])
+		label = "at least one of"
+	}
+	if len(branches) == 0 {
+		return ""
+	}
+
+	options := make([]string, 0, len(branches))
+	for _, branch := range branches {
+		branchSchema, ok := normalizeSchemaDefinition(branch)
+		if !ok {
+			continue
+		}
+		requiredFields := schemaStringSlice(branchSchema["required"])
+		if len(requiredFields) == 0 {
+			continue
+		}
+		options = append(options, strings.Join(requiredFields, ", "))
+	}
+	if len(options) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("provide %s: %s", label, strings.Join(options, " or "))
+}
+
+func formatTaskActionContext(params *connector.QueryParams) string {
+	if params == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(params.Messages)+1)
+	for _, msg := range params.Messages {
+		role := strings.ToUpper(strings.TrimSpace(msg.Role))
+		if role == "" {
+			role = "USER"
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", role, msg.Content))
+	}
+	if params.UserPrompt != nil && *params.UserPrompt != "" {
+		parts = append(parts, "USER: "+*params.UserPrompt)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func parseTaskActionFallbackResponse(raw string) (taskActionFallbackResponse, error) {
+	trimmed := strings.TrimSpace(raw)
+	candidates := extractJSONObjects(trimmed)
+	if len(candidates) == 0 {
+		return taskActionFallbackResponse{}, fmt.Errorf("task fallback response did not contain a valid JSON object")
+	}
+
+	var lastErr error
+	for _, candidate := range candidates {
+		var response taskActionFallbackResponse
+		if err := json.Unmarshal([]byte(candidate), &response); err != nil {
+			lastErr = fmt.Errorf("failed to parse task fallback response as JSON: %w", err)
+			continue
+		}
+
+		action := response.normalizedAction()
+		if action == "tool" || action == "final_answer" {
+			return response, nil
+		}
+		lastErr = fmt.Errorf("task fallback response has invalid action %q", action)
+	}
+
+	if lastErr != nil {
+		return taskActionFallbackResponse{}, lastErr
+	}
+	return taskActionFallbackResponse{}, fmt.Errorf("task fallback response did not contain a valid action object")
+}
+
+func (r taskActionFallbackResponse) normalizedAction() string {
+	action := strings.TrimSpace(r.Action)
+	if action == "" {
+		action = strings.TrimSpace(r.Type)
+	}
+	action = strings.ToLower(action)
+	switch action {
+	case "final", "answer", "complete", "done":
+		return "final_answer"
+	default:
+		if action == "" {
+			if strings.TrimSpace(r.Answer) != "" {
+				return "final_answer"
+			}
+			if r.Input != nil || strings.TrimSpace(r.Tool) != "" || strings.TrimSpace(r.ToolName) != "" {
+				return "tool"
+			}
+		}
+		return action
+	}
+}
+
+func (r taskActionFallbackResponse) normalizedToolName() string {
+	if toolName := strings.TrimSpace(r.Tool); toolName != "" {
+		return toolName
+	}
+	return strings.TrimSpace(r.ToolName)
+}
+
+func extractJSONObjects(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	objects := []string{}
+	depth := 0
+	start := -1
+	inString := false
+	escaped := false
+
+	for i, r := range raw {
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch r {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch r {
+		case '"':
+			inString = true
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			if depth == 0 {
+				continue
+			}
+			depth--
+			if depth == 0 && start >= 0 {
+				objects = append(objects, raw[start:i+1])
+				start = -1
+			}
+		}
+	}
+
+	return objects
+}

--- a/internal/agent/prompt_task.go
+++ b/internal/agent/prompt_task.go
@@ -1,0 +1,110 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/laszukdawid/terminal-agent/internal/connector"
+)
+
+const taskPromptTemplateText = `Original task: {{.OriginalQuery}}
+
+Current phase: {{.Phase}}
+Turn: {{.Iterations}} of {{.MaxTurns}}
+Tool calls: {{.ToolCalls}} of {{.MaxToolCalls}}
+Task root directory: {{.RootDir}}
+Current working directory: {{.CurrentDir}}{{.History}}
+
+What should I do next to complete this task? Should I use one of provided tools? Is the task finished? If so, provide the final answer.`
+
+const taskFinalSummaryTemplateText = `I've been working on this task: {{.OriginalQuery}}
+
+Task root directory: {{.RootDir}}
+Current working directory: {{.CurrentDir}}{{.History}}
+
+I've reached the task budget limit. Based on the above, provide a comprehensive final answer.`
+
+var (
+	taskPromptTemplate       = template.Must(template.New("task_prompt").Parse(taskPromptTemplateText))
+	taskFinalSummaryTemplate = template.Must(template.New("task_final_summary").Parse(taskFinalSummaryTemplateText))
+)
+
+type taskPromptTemplateData struct {
+	OriginalQuery string
+	Phase         TaskPhase
+	Iterations    int
+	MaxTurns      int
+	ToolCalls     int
+	MaxToolCalls  int
+	RootDir       string
+	CurrentDir    string
+	History       string
+}
+
+type taskFinalSummaryTemplateData struct {
+	OriginalQuery string
+	RootDir       string
+	CurrentDir    string
+	History       string
+}
+
+func buildTaskPrompt(state *TaskState) string {
+	return strings.TrimSpace(renderTaskTemplate(taskPromptTemplate, taskPromptTemplateData{
+		OriginalQuery: state.OriginalQuery,
+		Phase:         state.Phase,
+		Iterations:    state.Iterations,
+		MaxTurns:      state.MaxTurns,
+		ToolCalls:     state.ToolCalls,
+		MaxToolCalls:  state.MaxIterations,
+		RootDir:       state.Dirs.RootDir,
+		CurrentDir:    state.Dirs.CurrentDir,
+		History:       formatTaskPromptHistory(renderTaskHistoryForPrompt(state.Steps)),
+	}))
+}
+
+func (a *Agent) finalizeSummary(ctx context.Context, state *TaskState) (string, error) {
+	summary := renderTaskTemplate(taskFinalSummaryTemplate, taskFinalSummaryTemplateData{
+		OriginalQuery: state.OriginalQuery,
+		RootDir:       state.Dirs.RootDir,
+		CurrentDir:    state.Dirs.CurrentDir,
+		History:       formatTaskPromptHistory(renderTaskHistoryForSummary(state.Steps)),
+	})
+
+	qParams := connector.QueryParams{
+		UserPrompt: StringPtr(summary),
+		SysPrompt:  a.systemPromptTask,
+		MaxTokens:  a.maxTokens * 2,
+		Device:     a.device,
+	}
+
+	return a.Connector.Query(ctx, &qParams)
+}
+
+func renderTaskTemplate(tmpl *template.Template, data any) string {
+	var out bytes.Buffer
+	if err := tmpl.Execute(&out, data); err != nil {
+		panic(fmt.Sprintf("failed to render task prompt template: %v", err))
+	}
+	return out.String()
+}
+
+func formatTaskPromptHistory(history string) string {
+	if history == "" {
+		return ""
+	}
+	return "\n\nOrdered step history:\n" + history
+}
+
+func StringPtr(s string) *string {
+	return &s
+}
+
+func TruncateString(s string, maxLen int) string {
+	if len(s) > maxLen {
+		return s[:maxLen] + "... [Truncated]"
+	}
+	return s
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -2,9 +2,7 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -25,13 +23,21 @@ const (
 )
 
 type TaskOptions struct {
-	Allow       []string
-	Dirs        TaskDirs
-	Interaction TaskInteraction
-	OnStep      func(TaskStep)
+	Allow        []string
+	Dirs         TaskDirs
+	Interaction  TaskInteraction
+	OnStep       func(TaskStep)
+	OnToolOutput func(TaskToolOutputEvent) error
 	// Timeout bounds the whole task run. A value of 0 means no task-level
 	// timeout (unlimited). Caller context cancellation always takes precedence.
 	Timeout time.Duration
+}
+
+type TaskToolOutputEvent struct {
+	ToolName  string
+	ProcessID int
+	Output    string
+	Err       error
 }
 
 type TaskRunResult struct {
@@ -78,6 +84,7 @@ type taskExecutionState struct {
 	confirmations     *ConfirmationManager
 	successfulOutputs []taskToolOutput
 	onStep            func(TaskStep)
+	onToolOutput      func(TaskToolOutputEvent) error
 }
 
 func (r *taskExecutionState) appendStep(step TaskStep) {
@@ -210,6 +217,7 @@ func (a *Agent) newTaskExecutionState(query string, options TaskOptions) (*taskE
 		confirmations:     confirmations,
 		successfulOutputs: make([]taskToolOutput, 0, 1),
 		onStep:            options.OnStep,
+		onToolOutput:      options.OnToolOutput,
 	}, nil
 }
 
@@ -286,7 +294,7 @@ func (a *Agent) executeTaskTool(ctx context.Context, logger *zap.SugaredLogger, 
 	if err := ctx.Err(); err != nil {
 		return TaskRunResult{}, false, err
 	}
-	toolResult, err := runTaskTool(ctx, tool, response.ToolInput, run.state.Dirs)
+	toolResult, err := runTaskTool(ctx, tool, response.ToolInput, run.state.Dirs, newTaskToolOutputWriter(ctx, response.ToolName, run.onToolOutput))
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return TaskRunResult{}, false, ctxErr
@@ -445,436 +453,6 @@ func (a *Agent) nextTaskResponse(ctx context.Context, params *connector.QueryPar
 	return a.queryTaskActionFallback(ctx, params, taskTools)
 }
 
-type taskActionFallbackResponse struct {
-	Action   string         `json:"action,omitempty"`
-	Type     string         `json:"type,omitempty"`
-	Tool     string         `json:"tool,omitempty"`
-	ToolName string         `json:"tool_name,omitempty"`
-	Input    map[string]any `json:"input,omitempty"`
-	Answer   string         `json:"answer,omitempty"`
-	Thought  string         `json:"thought,omitempty"`
-}
-
-const taskActionSystemPromptSuffix = `
-
-For the next response, return exactly one JSON object and no surrounding markdown or prose. Put any brief reasoning inside the "thought" field.`
-
-const taskActionPromptTemplate = `Decide the next task step.
-
-Return exactly one JSON object. Do not return a schema, Markdown, or code fences.
-
-Valid response shapes:
-{"action":"tool","tool":"<tool name>","input":{...},"thought":"brief reason"}
-{"action":"final_answer","answer":"<final answer>","thought":"brief reason"}
-
-Rules:
-- Use "action", not "type".
-- Use "tool", not "tool_name".
-- The "input" field must contain the actual tool arguments for the chosen tool.
-- Do not return a JSON schema.
-- Use "final": true ONLY when raw output is definitely the final user-facing answer: concise, clean, readable, and requiring no interpretation.
-- If raw output needs interpretation, filtering, grouping, cleanup, explanation, or validation, do not set "final": true.
-
-Available tools:
-%s
-
-Task context:
-%s
-
-Return valid JSON only.`
-
-const taskActionRetryPromptTemplate = `Your previous response was invalid.
-
-Previous response:
-%s
-
-Problem:
-%s
-
-Return exactly one corrected JSON object and nothing else.
-
-Valid response shapes:
-{"action":"tool","tool":"<tool name>","input":{...},"thought":"brief reason"}
-{"action":"final_answer","answer":"<final answer>","thought":"brief reason"}
-
-Available tools:
-%s
-
-Task context:
-%s
-
-Return valid JSON only.`
-
-func (a *Agent) queryTaskActionFallback(ctx context.Context, params *connector.QueryParams, taskTools map[string]tools.Tool) (connector.LlmResponseWithTools, error) {
-	fallbackParams := *params
-	fallbackParams.Messages = nil
-	fallbackParams.Stream = false
-	fallbackParams.OnStream = nil
-	fallbackSystemPrompt := buildTaskActionSystemPrompt(params.SysPrompt)
-	fallbackParams.SysPrompt = &fallbackSystemPrompt
-
-	var lastRaw string
-	var lastErr error
-	for attempt := 0; attempt < maxTaskActionFallbackRuns; attempt++ {
-		if err := ctx.Err(); err != nil {
-			return connector.LlmResponseWithTools{}, err
-		}
-		prompt := a.buildTaskActionPrompt(params, taskTools, lastRaw, lastErr)
-		fallbackParams.UserPrompt = &prompt
-
-		raw, err := a.Connector.Query(ctx, &fallbackParams)
-		if err != nil {
-			return connector.LlmResponseWithTools{}, err
-		}
-
-		parsed, err := parseTaskActionFallbackResponse(raw)
-		if err != nil {
-			lastRaw = raw
-			lastErr = err
-			continue
-		}
-
-		response, err := buildTaskActionResponse(parsed)
-		if err != nil {
-			lastRaw = raw
-			lastErr = err
-			continue
-		}
-
-		return response, nil
-	}
-
-	return connector.LlmResponseWithTools{}, fmt.Errorf("task fallback produced invalid action after %d attempts: %w", maxTaskActionFallbackRuns, lastErr)
-}
-
-func buildTaskActionSystemPrompt(base *string) string {
-	if strings.TrimSpace(*base) == "" {
-		return strings.TrimSpace(taskActionSystemPromptSuffix)
-	}
-	return strings.TrimSpace(*base) + taskActionSystemPromptSuffix
-}
-
-func buildTaskActionResponse(parsed taskActionFallbackResponse) (connector.LlmResponseWithTools, error) {
-	response := connector.LlmResponseWithTools{Response: strings.TrimSpace(parsed.Thought)}
-	action := parsed.normalizedAction()
-	if action == "final_answer" {
-		response.ToolUse = true
-		response.ToolName = ToolNameFinalAnswer
-		response.ToolInput = map[string]any{"answer": strings.TrimSpace(parsed.Answer)}
-		return response, nil
-	}
-	if action != "tool" {
-		return connector.LlmResponseWithTools{}, fmt.Errorf("task fallback response has invalid action %q", action)
-	}
-
-	toolName := parsed.normalizedToolName()
-	if toolName == "" {
-		return connector.LlmResponseWithTools{}, fmt.Errorf("task fallback response is missing tool name")
-	}
-	if parsed.Input == nil {
-		parsed.Input = map[string]any{}
-	}
-
-	response.ToolUse = true
-	response.ToolName = toolName
-	response.ToolInput = parsed.Input
-	return response, nil
-}
-
-func (a *Agent) buildTaskActionPrompt(params *connector.QueryParams, taskTools map[string]tools.Tool, previousRaw string, previousErr error) string {
-	toolsText := formatTaskActionTools(taskTools)
-	contextText := formatTaskActionContext(params)
-	if previousErr == nil {
-		return fmt.Sprintf(taskActionPromptTemplate, toolsText, contextText)
-	}
-	return fmt.Sprintf(
-		taskActionRetryPromptTemplate,
-		TruncateString(strings.TrimSpace(previousRaw), 1200),
-		previousErr.Error(),
-		toolsText,
-		contextText,
-	)
-}
-
-func formatTaskActionTools(execTools map[string]tools.Tool) string {
-	names := make([]string, 0, len(execTools))
-	for name := range execTools {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	entries := make([]string, 0, len(names))
-	for _, name := range names {
-		tool := execTools[name]
-		entry := fmt.Sprintf("- %s: %s", tool.Name(), tool.Description())
-		schemaHints := formatTaskActionSchemaHints(tool.InputSchema())
-		if schemaHints != "" {
-			entry += "\n" + schemaHints
-		}
-		entries = append(entries, entry)
-	}
-	return strings.Join(entries, "\n")
-}
-
-func formatTaskActionSchemaHints(schema map[string]any) string {
-	properties, ok := normalizeSchemaMap(schema["properties"])
-	if !ok || len(properties) == 0 {
-		return ""
-	}
-
-	required := make(map[string]bool)
-	for _, name := range schemaStringSlice(schema["required"]) {
-		required[name] = true
-	}
-
-	fieldNames := make([]string, 0, len(properties))
-	for name := range properties {
-		fieldNames = append(fieldNames, name)
-	}
-	sort.Strings(fieldNames)
-
-	lines := make([]string, 0, len(fieldNames)+2)
-	for _, fieldName := range fieldNames {
-		definition, ok := normalizeSchemaDefinition(properties[fieldName])
-		if !ok {
-			continue
-		}
-		line := fmt.Sprintf("  - %s (%s, %s)", fieldName, schemaFieldType(definition), requiredLabel(required[fieldName]))
-		if description, _ := definition["description"].(string); description != "" {
-			line += ": " + description
-		}
-		if enumValues := schemaStringSlice(definition["enum"]); len(enumValues) > 0 {
-			line += fmt.Sprintf(" Allowed values: %s.", strings.Join(enumValues, ", "))
-		}
-		lines = append(lines, line)
-	}
-
-	if requirementHint := formatTaskActionRequirementHints(schema); requirementHint != "" {
-		lines = append(lines, "  - requirement: "+requirementHint)
-	}
-
-	return strings.Join(lines, "\n")
-}
-
-func schemaFieldType(definition map[string]any) string {
-	if typeName, _ := definition["type"].(string); typeName != "" {
-		return typeName
-	}
-	return "value"
-}
-
-func requiredLabel(required bool) string {
-	if required {
-		return "required"
-	}
-	return "optional"
-}
-
-func formatTaskActionRequirementHints(schema map[string]any) string {
-	branches := schemaAnySlice(schema["oneOf"])
-	label := "exactly one of"
-	if len(branches) == 0 {
-		branches = schemaAnySlice(schema["anyOf"])
-		label = "at least one of"
-	}
-	if len(branches) == 0 {
-		return ""
-	}
-
-	options := make([]string, 0, len(branches))
-	for _, branch := range branches {
-		branchSchema, ok := normalizeSchemaDefinition(branch)
-		if !ok {
-			continue
-		}
-		requiredFields := schemaStringSlice(branchSchema["required"])
-		if len(requiredFields) == 0 {
-			continue
-		}
-		options = append(options, strings.Join(requiredFields, ", "))
-	}
-	if len(options) == 0 {
-		return ""
-	}
-	return fmt.Sprintf("provide %s: %s", label, strings.Join(options, " or "))
-}
-
-func formatTaskActionContext(params *connector.QueryParams) string {
-	if params == nil {
-		return ""
-	}
-	parts := make([]string, 0, len(params.Messages)+1)
-	for _, msg := range params.Messages {
-		role := strings.ToUpper(strings.TrimSpace(msg.Role))
-		if role == "" {
-			role = "USER"
-		}
-		parts = append(parts, fmt.Sprintf("%s: %s", role, msg.Content))
-	}
-	if params.UserPrompt != nil && *params.UserPrompt != "" {
-		parts = append(parts, "USER: "+*params.UserPrompt)
-	}
-	return strings.Join(parts, "\n\n")
-}
-
-func parseTaskActionFallbackResponse(raw string) (taskActionFallbackResponse, error) {
-	trimmed := strings.TrimSpace(raw)
-	candidates := extractJSONObjects(trimmed)
-	if len(candidates) == 0 {
-		return taskActionFallbackResponse{}, fmt.Errorf("task fallback response did not contain a valid JSON object")
-	}
-
-	var lastErr error
-	for _, candidate := range candidates {
-		var response taskActionFallbackResponse
-		if err := json.Unmarshal([]byte(candidate), &response); err != nil {
-			lastErr = fmt.Errorf("failed to parse task fallback response as JSON: %w", err)
-			continue
-		}
-
-		action := response.normalizedAction()
-		if action == "tool" || action == "final_answer" {
-			return response, nil
-		}
-		lastErr = fmt.Errorf("task fallback response has invalid action %q", action)
-	}
-
-	if lastErr != nil {
-		return taskActionFallbackResponse{}, lastErr
-	}
-	return taskActionFallbackResponse{}, fmt.Errorf("task fallback response did not contain a valid action object")
-}
-
-func (r taskActionFallbackResponse) normalizedAction() string {
-	action := strings.TrimSpace(r.Action)
-	if action == "" {
-		action = strings.TrimSpace(r.Type)
-	}
-	action = strings.ToLower(action)
-	switch action {
-	case "final", "answer", "complete", "done":
-		return "final_answer"
-	default:
-		if action == "" {
-			if strings.TrimSpace(r.Answer) != "" {
-				return "final_answer"
-			}
-			if r.Input != nil || strings.TrimSpace(r.Tool) != "" || strings.TrimSpace(r.ToolName) != "" {
-				return "tool"
-			}
-		}
-		return action
-	}
-}
-
-func (r taskActionFallbackResponse) normalizedToolName() string {
-	if toolName := strings.TrimSpace(r.Tool); toolName != "" {
-		return toolName
-	}
-	return strings.TrimSpace(r.ToolName)
-}
-
-func extractJSONObjects(raw string) []string {
-	if raw == "" {
-		return nil
-	}
-
-	objects := []string{}
-	depth := 0
-	start := -1
-	inString := false
-	escaped := false
-
-	for i, r := range raw {
-		if inString {
-			if escaped {
-				escaped = false
-				continue
-			}
-			switch r {
-			case '\\':
-				escaped = true
-			case '"':
-				inString = false
-			}
-			continue
-		}
-
-		switch r {
-		case '"':
-			inString = true
-		case '{':
-			if depth == 0 {
-				start = i
-			}
-			depth++
-		case '}':
-			if depth == 0 {
-				continue
-			}
-			depth--
-			if depth == 0 && start >= 0 {
-				objects = append(objects, raw[start:i+1])
-				start = -1
-			}
-		}
-	}
-
-	return objects
-}
-
-func buildTaskPrompt(state *TaskState) string {
-	var prompt strings.Builder
-	fmt.Fprintf(&prompt, "Original task: %s\n\n", state.OriginalQuery)
-	fmt.Fprintf(&prompt, "Current phase: %s\n", state.Phase)
-	fmt.Fprintf(&prompt, "Turn: %d of %d\n", state.Iterations, state.MaxTurns)
-	fmt.Fprintf(&prompt, "Tool calls: %d of %d\n", state.ToolCalls, state.MaxIterations)
-	fmt.Fprintf(&prompt, "Task root directory: %s\n", state.Dirs.RootDir)
-	fmt.Fprintf(&prompt, "Current working directory: %s", state.Dirs.CurrentDir)
-
-	if history := renderTaskHistoryForPrompt(state.Steps); history != "" {
-		prompt.WriteString("\n\nOrdered step history:\n")
-		prompt.WriteString(history)
-	}
-
-	prompt.WriteString("\n\nWhat should I do next to complete this task? Should I use one of provided tools? Is the task finished? If so, provide the final answer.")
-	return strings.TrimSpace(prompt.String())
-}
-
-func (a *Agent) finalizeSummary(ctx context.Context, state *TaskState) (string, error) {
-	var summary strings.Builder
-	fmt.Fprintf(&summary, "I've been working on this task: %s\n\n", state.OriginalQuery)
-	fmt.Fprintf(&summary, "Task root directory: %s\n", state.Dirs.RootDir)
-	fmt.Fprintf(&summary, "Current working directory: %s", state.Dirs.CurrentDir)
-
-	if history := renderTaskHistoryForSummary(state.Steps); history != "" {
-		summary.WriteString("\n\nOrdered step history:\n")
-		summary.WriteString(history)
-	}
-
-	summary.WriteString("\n\nI've reached the task budget limit. Based on the above, provide a comprehensive final answer.")
-
-	qParams := connector.QueryParams{
-		UserPrompt: StringPtr(summary.String()),
-		SysPrompt:  a.systemPromptTask,
-		MaxTokens:  a.maxTokens * 2,
-		Device:     a.device,
-	}
-
-	return a.Connector.Query(ctx, &qParams)
-}
-
-func StringPtr(s string) *string {
-	return &s
-}
-
-func TruncateString(s string, maxLen int) string {
-	if len(s) > maxLen {
-		return s[:maxLen] + "... [Truncated]"
-	}
-	return s
-}
-
 func selectRawTaskOutput(outputs []taskToolOutput) taskToolOutput {
 	return selectTaskRawOutput(outputs)
 }
@@ -891,127 +469,4 @@ func permissionCategoryFor(tool tools.Tool) tools.PermissionCategory {
 		return categorized.PermissionCategory()
 	}
 	return tools.PermissionExecute
-}
-
-type askUserTool struct {
-	name        string
-	description string
-	inputSchema map[string]any
-	interaction TaskInteraction
-}
-
-func NewAskUserTool(interaction TaskInteraction) *askUserTool {
-	return &askUserTool{
-		name:        UserClarificationToolName,
-		description: "Ask the user for clarification or additional information. This tool is used when the model needs more context to proceed with the task.",
-		interaction: interaction,
-		inputSchema: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"question": map[string]string{
-					"type":        "string",
-					"description": "Ask a question to the user to get more info required to solve or clarify their problem",
-				},
-			},
-			"required": []string{"question"},
-		},
-	}
-}
-
-func (t *askUserTool) Name() string {
-	return t.name
-}
-
-func (t *askUserTool) PermissionCategory() tools.PermissionCategory {
-	return tools.PermissionRead
-}
-
-func (t *askUserTool) Description() string {
-	return t.description
-}
-
-func (t *askUserTool) InputSchema() map[string]any {
-	return t.inputSchema
-}
-
-func (t *askUserTool) HelpText() string {
-	return fmt.Sprintf("Help for %s: %s\n\n%s", t.Name(), t.Description(), t.InputSchema())
-}
-
-func (t *askUserTool) RunSchema(input map[string]any) (string, error) {
-	question, ok := input["question"].(string)
-	if !ok {
-		return "", fmt.Errorf("failed to extract question from tool input")
-	}
-
-	if t.interaction == nil {
-		return "", ErrTaskInteractionRequired
-	}
-
-	userInput, err := t.interaction.Clarify(TaskClarificationRequest{Question: question})
-	if err != nil {
-		return "", fmt.Errorf("user input error: %w", err)
-	}
-
-	return userInput, nil
-}
-
-func (t *askUserTool) Run(input *string) (string, error) {
-	return t.RunSchema(map[string]any{"question": *input})
-}
-
-type finalAnswerTool struct {
-	name        string
-	description string
-	inputSchema map[string]any
-}
-
-func NewFinalAnswerTool() *finalAnswerTool {
-	return &finalAnswerTool{
-		name:        ToolNameFinalAnswer,
-		description: "Provide the final answer to the task.",
-		inputSchema: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"answer": map[string]string{
-					"type":        "string",
-					"description": "Call this tool when the task is complete and you want to provide the final answer.",
-				},
-			},
-			"required": []string{"answer"},
-		},
-	}
-}
-
-func (t *finalAnswerTool) Name() string {
-	return t.name
-}
-
-func (t *finalAnswerTool) PermissionCategory() tools.PermissionCategory {
-	return tools.PermissionRead
-}
-
-func (t *finalAnswerTool) Description() string {
-	return t.description
-}
-
-func (t *finalAnswerTool) InputSchema() map[string]any {
-	return t.inputSchema
-}
-
-func (t *finalAnswerTool) HelpText() string {
-	return fmt.Sprintf("Help for %s: %s\n\n%s", t.Name(), t.Description(), t.InputSchema())
-}
-
-func (t *finalAnswerTool) RunSchema(input map[string]any) (string, error) {
-	answer, ok := input["answer"].(string)
-	if !ok {
-		return "", fmt.Errorf("failed to extract answer from tool input")
-	}
-
-	return answer, nil
-}
-
-func (t *finalAnswerTool) Run(input *string) (string, error) {
-	return t.RunSchema(map[string]any{"answer": *input})
 }

--- a/internal/agent/task_helpers.go
+++ b/internal/agent/task_helpers.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,13 +28,14 @@ func selectTaskRawOutput(outputs []taskToolOutput) taskToolOutput {
 	return taskToolOutput{}
 }
 
-func runTaskTool(ctx context.Context, tool tools.Tool, input map[string]any, dirs TaskDirs) (string, error) {
+func runTaskTool(ctx context.Context, tool tools.Tool, input map[string]any, dirs TaskDirs, output io.Writer) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
 	execCtx := tools.ToolExecutionContext{
 		RootDir:    dirs.RootDir,
 		CurrentDir: dirs.CurrentDir,
+		Output:     output,
 	}
 	if contextAwareTool, ok := tool.(tools.ContextAwareTool); ok {
 		return contextAwareTool.RunSchemaContext(ctx, input, execCtx)
@@ -159,55 +161,4 @@ func isTaskDisplayOrientedTool(toolName string) bool {
 	default:
 		return false
 	}
-}
-
-type changeDirectoryTool struct {
-	name        string
-	description string
-	inputSchema map[string]any
-}
-
-func NewChangeDirectoryTool() *changeDirectoryTool {
-	return &changeDirectoryTool{
-		name:        ToolNameChangeDirectory,
-		description: "Change the task's current working directory. Use this before running tools that should operate from a different subdirectory.",
-		inputSchema: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"path": map[string]string{
-					"type":        "string",
-					"description": "Directory path relative to the current working directory, or absolute within the task root.",
-				},
-			},
-			"required": []string{"path"},
-		},
-	}
-}
-
-func (t *changeDirectoryTool) Name() string {
-	return t.name
-}
-
-func (t *changeDirectoryTool) Description() string {
-	return t.description
-}
-
-func (t *changeDirectoryTool) InputSchema() map[string]any {
-	return t.inputSchema
-}
-
-func (t *changeDirectoryTool) HelpText() string {
-	return fmt.Sprintf("Help for %s: %s\n\n%v", t.Name(), t.Description(), t.InputSchema())
-}
-
-func (t *changeDirectoryTool) RunSchema(input map[string]any) (string, error) {
-	path, ok := input["path"].(string)
-	if !ok || strings.TrimSpace(path) == "" {
-		return "", fmt.Errorf("failed to extract path from tool input")
-	}
-	return path, nil
-}
-
-func (t *changeDirectoryTool) Run(input *string) (string, error) {
-	return t.RunSchema(map[string]any{"path": *input})
 }

--- a/internal/agent/task_helpers_test.go
+++ b/internal/agent/task_helpers_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -46,32 +47,49 @@ func (t *legacyTaskTool) RunSchema(input map[string]any) (string, error) {
 }
 func (t *legacyTaskTool) Run(*string) (string, error) { return "legacy", nil }
 
-func TestRunTaskToolPassesTaskContextToContextAwareTool(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	input := map[string]any{"command": "pwd"}
-	tool := &contextAwareTaskTool{}
-	dirs := TaskDirs{RootDir: "/repo", CurrentDir: "/repo/internal"}
+func TestRunTaskTool(t *testing.T) {
+	t.Run("passes task context to context-aware tool", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		input := map[string]any{"command": "pwd"}
+		tool := &contextAwareTaskTool{}
+		dirs := TaskDirs{RootDir: "/repo", CurrentDir: "/repo/internal"}
 
-	output, err := runTaskTool(ctx, tool, input, dirs)
+		output, err := runTaskTool(ctx, tool, input, dirs, nil)
 
-	require.NoError(t, err)
-	assert.Equal(t, "context-aware", output)
-	assert.False(t, tool.legacyCalled)
-	assert.Equal(t, input, tool.receivedInput)
-	assert.Equal(t, tools.ToolExecutionContext{RootDir: dirs.RootDir, CurrentDir: dirs.CurrentDir}, tool.receivedExec)
-	assert.Equal(t, ctx, tool.receivedCtx)
-	cancel()
-	require.ErrorIs(t, tool.receivedCtx.Err(), context.Canceled)
-}
+		require.NoError(t, err)
+		assert.Equal(t, "context-aware", output)
+		assert.False(t, tool.legacyCalled)
+		assert.Equal(t, input, tool.receivedInput)
+		assert.Equal(t, dirs.RootDir, tool.receivedExec.RootDir)
+		assert.Equal(t, dirs.CurrentDir, tool.receivedExec.CurrentDir)
+		assert.Nil(t, tool.receivedExec.Output)
+		assert.Equal(t, ctx, tool.receivedCtx)
+		cancel()
+		require.ErrorIs(t, tool.receivedCtx.Err(), context.Canceled)
+	})
 
-func TestRunTaskToolFallsBackToLegacyTool(t *testing.T) {
-	input := map[string]any{"value": "ok"}
-	tool := &legacyTaskTool{}
+	t.Run("passes output writer to context-aware tool", func(t *testing.T) {
+		input := map[string]any{"command": "pwd"}
+		tool := &contextAwareTaskTool{}
+		dirs := TaskDirs{RootDir: "/repo", CurrentDir: "/repo/internal"}
+		var liveOutput bytes.Buffer
 
-	output, err := runTaskTool(context.Background(), tool, input, TaskDirs{})
+		output, err := runTaskTool(context.Background(), tool, input, dirs, &liveOutput)
 
-	require.NoError(t, err)
-	assert.Equal(t, "legacy", output)
-	assert.Equal(t, input, tool.receivedInput)
+		require.NoError(t, err)
+		assert.Equal(t, "context-aware", output)
+		assert.Same(t, &liveOutput, tool.receivedExec.Output)
+	})
+
+	t.Run("falls back to legacy tool", func(t *testing.T) {
+		input := map[string]any{"value": "ok"}
+		tool := &legacyTaskTool{}
+
+		output, err := runTaskTool(context.Background(), tool, input, TaskDirs{}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "legacy", output)
+		assert.Equal(t, input, tool.receivedInput)
+	})
 }

--- a/internal/agent/task_output.go
+++ b/internal/agent/task_output.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"context"
+	"io"
+)
+
+type taskToolOutputWriter struct {
+	ctx      context.Context
+	toolName string
+	pid      int
+	disabled bool
+	warned   bool
+	onOutput func(TaskToolOutputEvent) error
+}
+
+func newTaskToolOutputWriter(ctx context.Context, toolName string, onOutput func(TaskToolOutputEvent) error) io.Writer {
+	if onOutput == nil {
+		return nil
+	}
+	return &taskToolOutputWriter{
+		ctx:      ctx,
+		toolName: toolName,
+		onOutput: onOutput,
+	}
+}
+
+func (w *taskToolOutputWriter) ProcessStarted(pid int) {
+	w.pid = pid
+}
+
+func (w *taskToolOutputWriter) Write(p []byte) (int, error) {
+	if w.disabled {
+		return len(p), nil
+	}
+	if err := w.onOutput(TaskToolOutputEvent{ToolName: w.toolName, ProcessID: w.pid, Output: string(p)}); err != nil {
+		if ctxErr := w.ctx.Err(); ctxErr != nil {
+			return 0, ctxErr
+		}
+		w.disabled = true
+		if !w.warned {
+			w.warned = true
+			_ = w.onOutput(TaskToolOutputEvent{ToolName: w.toolName, ProcessID: w.pid, Err: err})
+		}
+	}
+	return len(p), nil
+}

--- a/internal/agent/task_output_test.go
+++ b/internal/agent/task_output_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskToolOutputWriter(t *testing.T) {
+	t.Run("warns and continues on display error", func(t *testing.T) {
+		displayErr := errors.New("display failed")
+		var warnedTool string
+		var warnedPID int
+		var warnedErr error
+		writeCalls := 0
+
+		writer := newTaskToolOutputWriter(
+			context.Background(),
+			"unix",
+			func(event TaskToolOutputEvent) error {
+				if event.Err != nil {
+					warnedTool = event.ToolName
+					warnedPID = event.ProcessID
+					warnedErr = event.Err
+					return nil
+				}
+				writeCalls++
+				return displayErr
+			},
+		)
+		processWriter, ok := writer.(interface{ ProcessStarted(int) })
+		require.True(t, ok)
+		processWriter.ProcessStarted(1234)
+
+		n, err := writer.Write([]byte("first"))
+		require.NoError(t, err)
+		assert.Equal(t, 5, n)
+
+		n, err = writer.Write([]byte("second"))
+		require.NoError(t, err)
+		assert.Equal(t, 6, n)
+
+		assert.Equal(t, 1, writeCalls)
+		assert.Equal(t, "unix", warnedTool)
+		assert.Equal(t, 1234, warnedPID)
+		assert.ErrorIs(t, warnedErr, displayErr)
+	})
+
+	t.Run("returns context error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		writer := newTaskToolOutputWriter(
+			ctx,
+			"unix",
+			func(TaskToolOutputEvent) error { return errors.New("display failed") },
+		)
+
+		n, err := writer.Write([]byte("output"))
+
+		assert.Equal(t, 0, n)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -759,7 +759,13 @@ func TestTaskWithOptionsResultReturnsDirectRawOutputForFinalTool(t *testing.T) {
 }
 
 func TestTaskActionPromptFinalGuidanceIsSelective(t *testing.T) {
-	prompt := taskActionPromptTemplate
+	userPrompt := "task context"
+	prompt := (&Agent{}).buildTaskActionPrompt(
+		&connector.QueryParams{UserPrompt: &userPrompt},
+		map[string]tools.Tool{},
+		"",
+		nil,
+	)
 
 	assert.Contains(t, prompt, `Use "final": true ONLY when raw output is definitely the final user-facing answer`)
 	assert.Contains(t, prompt, `If raw output needs interpretation, filtering, grouping, cleanup, explanation, or validation, do not set "final": true`)

--- a/internal/agent/task_tools.go
+++ b/internal/agent/task_tools.go
@@ -1,0 +1,29 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/laszukdawid/terminal-agent/internal/agent/tasktools"
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+)
+
+func NewAskUserTool(interaction TaskInteraction) tools.Tool {
+	return tasktools.NewAskUser(UserClarificationToolName, func(question string) (string, error) {
+		if interaction == nil {
+			return "", ErrTaskInteractionRequired
+		}
+		userInput, err := interaction.Clarify(TaskClarificationRequest{Question: question})
+		if err != nil {
+			return "", fmt.Errorf("user input error: %w", err)
+		}
+		return userInput, nil
+	})
+}
+
+func NewFinalAnswerTool() tools.Tool {
+	return tasktools.NewFinalAnswer(ToolNameFinalAnswer)
+}
+
+func NewChangeDirectoryTool() tools.Tool {
+	return tasktools.NewChangeDirectory(ToolNameChangeDirectory)
+}

--- a/internal/agent/tasktools/ask_user.go
+++ b/internal/agent/tasktools/ask_user.go
@@ -1,0 +1,67 @@
+package tasktools
+
+import (
+	"fmt"
+
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+)
+
+type askUserTool struct {
+	name        string
+	description string
+	inputSchema map[string]any
+	clarify     func(string) (string, error)
+}
+
+func NewAskUser(name string, clarify func(string) (string, error)) tools.Tool {
+	return &askUserTool{
+		name:        name,
+		description: "Ask the user for clarification or additional information. This tool is used when the model needs more context to proceed with the task.",
+		clarify:     clarify,
+		inputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"question": map[string]string{
+					"type":        "string",
+					"description": "Ask a question to the user to get more info required to solve or clarify their problem",
+				},
+			},
+			"required": []string{"question"},
+		},
+	}
+}
+
+func (t *askUserTool) Name() string {
+	return t.name
+}
+
+func (t *askUserTool) PermissionCategory() tools.PermissionCategory {
+	return tools.PermissionRead
+}
+
+func (t *askUserTool) Description() string {
+	return t.description
+}
+
+func (t *askUserTool) InputSchema() map[string]any {
+	return t.inputSchema
+}
+
+func (t *askUserTool) HelpText() string {
+	return fmt.Sprintf("Help for %s: %s\n\n%s", t.Name(), t.Description(), t.InputSchema())
+}
+
+func (t *askUserTool) RunSchema(input map[string]any) (string, error) {
+	question, ok := input["question"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed to extract question from tool input")
+	}
+	if t.clarify == nil {
+		return "", fmt.Errorf("task interaction required")
+	}
+	return t.clarify(question)
+}
+
+func (t *askUserTool) Run(input *string) (string, error) {
+	return t.RunSchema(map[string]any{"question": *input})
+}

--- a/internal/agent/tasktools/change_directory.go
+++ b/internal/agent/tasktools/change_directory.go
@@ -1,0 +1,57 @@
+package tasktools
+
+import (
+	"fmt"
+	"strings"
+)
+
+type changeDirectoryTool struct {
+	name        string
+	description string
+	inputSchema map[string]any
+}
+
+func NewChangeDirectory(name string) *changeDirectoryTool {
+	return &changeDirectoryTool{
+		name:        name,
+		description: "Change the task's current working directory. Use this before running tools that should operate from a different subdirectory.",
+		inputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]string{
+					"type":        "string",
+					"description": "Directory path relative to the current working directory, or absolute within the task root.",
+				},
+			},
+			"required": []string{"path"},
+		},
+	}
+}
+
+func (t *changeDirectoryTool) Name() string {
+	return t.name
+}
+
+func (t *changeDirectoryTool) Description() string {
+	return t.description
+}
+
+func (t *changeDirectoryTool) InputSchema() map[string]any {
+	return t.inputSchema
+}
+
+func (t *changeDirectoryTool) HelpText() string {
+	return fmt.Sprintf("Help for %s: %s\n\n%v", t.Name(), t.Description(), t.InputSchema())
+}
+
+func (t *changeDirectoryTool) RunSchema(input map[string]any) (string, error) {
+	path, ok := input["path"].(string)
+	if !ok || strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("failed to extract path from tool input")
+	}
+	return path, nil
+}
+
+func (t *changeDirectoryTool) Run(input *string) (string, error) {
+	return t.RunSchema(map[string]any{"path": *input})
+}

--- a/internal/agent/tasktools/final_answer.go
+++ b/internal/agent/tasktools/final_answer.go
@@ -1,0 +1,62 @@
+package tasktools
+
+import (
+	"fmt"
+
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+)
+
+type finalAnswerTool struct {
+	name        string
+	description string
+	inputSchema map[string]any
+}
+
+func NewFinalAnswer(name string) *finalAnswerTool {
+	return &finalAnswerTool{
+		name:        name,
+		description: "Provide the final answer to the task.",
+		inputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"answer": map[string]string{
+					"type":        "string",
+					"description": "Call this tool when the task is complete and you want to provide the final answer.",
+				},
+			},
+			"required": []string{"answer"},
+		},
+	}
+}
+
+func (t *finalAnswerTool) Name() string {
+	return t.name
+}
+
+func (t *finalAnswerTool) PermissionCategory() tools.PermissionCategory {
+	return tools.PermissionRead
+}
+
+func (t *finalAnswerTool) Description() string {
+	return t.description
+}
+
+func (t *finalAnswerTool) InputSchema() map[string]any {
+	return t.inputSchema
+}
+
+func (t *finalAnswerTool) HelpText() string {
+	return fmt.Sprintf("Help for %s: %s\n\n%s", t.Name(), t.Description(), t.InputSchema())
+}
+
+func (t *finalAnswerTool) RunSchema(input map[string]any) (string, error) {
+	answer, ok := input["answer"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed to extract answer from tool input")
+	}
+	return answer, nil
+}
+
+func (t *finalAnswerTool) Run(input *string) (string, error) {
+	return t.RunSchema(map[string]any{"answer": *input})
+}

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -26,6 +26,7 @@ type EventType string
 const (
 	EventStarted             EventType = "started"
 	EventOutputDelta         EventType = "output_delta"
+	EventWarning             EventType = "warning"
 	EventConfirmationNeeded  EventType = "confirmation_needed"
 	EventClarificationNeeded EventType = "clarification_needed"
 	EventCompleted           EventType = "completed"
@@ -56,6 +57,7 @@ type Event struct {
 	FinalOutput     string
 	Err             error
 	ToolName        string
+	ProcessID       int
 	ToolInput       map[string]any
 	ToolResult      string
 	RawOutput       string

--- a/internal/app/task.go
+++ b/internal/app/task.go
@@ -13,6 +13,7 @@ import (
 	internalagent "github.com/laszukdawid/terminal-agent/internal/agent"
 	"github.com/laszukdawid/terminal-agent/internal/config"
 	"github.com/laszukdawid/terminal-agent/internal/sessionlog"
+	log "github.com/laszukdawid/terminal-agent/internal/utils"
 )
 
 type TaskRequest struct {
@@ -73,8 +74,27 @@ func (s *service) runTaskEvents(ctx context.Context, req TaskRequest, interactio
 	onStep := func(step internalagent.TaskStep) {
 		recorder.Write(taskStepToRecord(step))
 	}
+	onToolOutput := func(output internalagent.TaskToolOutputEvent) error {
+		if output.Err != nil {
+			warning := newEvent(RunKindTask, EventWarning)
+			warning.ToolName = output.ToolName
+			warning.ProcessID = output.ProcessID
+			warning.Text = formatToolOutputWarning(output.ProcessID, output.Err)
+			if emitErr := emitEvent(ctx, events, warning); emitErr != nil {
+				// If this channel is the failing display path, logs are the only reliable signal.
+				log.Warnw("Failed to emit task output warning", "tool", output.ToolName, "process_id", output.ProcessID, "warning", warning.Text, "error", emitErr)
+			}
+			return nil
+		}
 
-	result, err := executeTask(ctx, req, interaction, onStep)
+		event := newEvent(RunKindTask, EventOutputDelta)
+		event.Text = output.Output
+		event.ToolName = output.ToolName
+		event.ProcessID = output.ProcessID
+		return emitEvent(ctx, events, event)
+	}
+
+	result, err := executeTask(ctx, req, interaction, onStep, onToolOutput)
 	if err != nil {
 		failed := newEvent(RunKindTask, EventFailed)
 		failed.Err = err
@@ -93,7 +113,7 @@ func (s *service) runTaskEvents(ctx context.Context, req TaskRequest, interactio
 	_ = emitEvent(ctx, events, completed)
 }
 
-func executeTask(ctx context.Context, req TaskRequest, interaction internalagent.TaskInteraction, onStep func(internalagent.TaskStep)) (TaskResult, error) {
+func executeTask(ctx context.Context, req TaskRequest, interaction internalagent.TaskInteraction, onStep func(internalagent.TaskStep), onToolOutput func(internalagent.TaskToolOutputEvent) error) (TaskResult, error) {
 	if strings.TrimSpace(req.Message) == "" {
 		return TaskResult{}, internalagent.ErrEmptyQuery
 	}
@@ -126,10 +146,11 @@ func executeTask(ctx context.Context, req TaskRequest, interaction internalagent
 	agentInstance := runtime.NewAgent(PromptSet{Task: taskPrompt})
 	agentInstance.SetDevice(req.Device)
 	response, err := agentInstance.TaskWithOptionsResult(ctx, req.Message, internalagent.TaskOptions{
-		Allow:       req.Allow,
-		Interaction: interaction,
-		OnStep:      onStep,
-		Timeout:     req.Timeout,
+		Allow:        req.Allow,
+		Interaction:  interaction,
+		OnStep:       onStep,
+		OnToolOutput: onToolOutput,
+		Timeout:      req.Timeout,
 		Dirs: internalagent.TaskDirs{
 			RootDir:    taskRootDir,
 			CurrentDir: taskRootDir,
@@ -146,6 +167,13 @@ func executeTask(ctx context.Context, req TaskRequest, interaction internalagent
 		RawOutputTool:   response.RawOutputTool,
 		DirectRawOutput: response.DirectRawOutput,
 	}, nil
+}
+
+func formatToolOutputWarning(processID int, err error) string {
+	if processID > 0 {
+		return fmt.Sprintf("Live output display failed; process %d is still running: %v", processID, err)
+	}
+	return fmt.Sprintf("Live output display failed; process is still running: %v", err)
 }
 
 var errTaskEventAlreadyReplied = errors.New("task event already replied")

--- a/internal/commands/task_cmd.go
+++ b/internal/commands/task_cmd.go
@@ -73,9 +73,28 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 				return fmt.Errorf("failed to request a task: %w", err)
 			}
 
+			printFlag, printFlagErr := flags.GetBool("print")
+			if printFlagErr != nil {
+				printFlag = true
+			}
+
 			result := app.TaskResult{Request: userRequest}
+			printedStreamedToolOutput := false
+			lastStreamChunkEndedWithNewline := true
 			for event := range events {
 				switch event.Type {
+				case app.EventOutputDelta:
+					if printFlag {
+						printedStreamedToolOutput = true
+						if event.Text != "" {
+							lastStreamChunkEndedWithNewline = strings.HasSuffix(event.Text, "\n")
+						}
+						cmd.Print(event.Text)
+					}
+				case app.EventWarning:
+					if event.Text != "" {
+						cmd.PrintErrf("Warning: %s\n", event.Text)
+					}
 				case app.EventConfirmationNeeded:
 					decision, promptErr := promptTaskConfirmation(cmd, inputReader, event.Confirmation)
 					if promptErr != nil {
@@ -94,7 +113,9 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 					}
 				case app.EventCompleted:
 					result.Response = event.FinalOutput
-					result.RawOutput = event.RawOutput
+					if !printedStreamedToolOutput {
+						result.RawOutput = event.RawOutput
+					}
 					result.RawOutputTool = event.RawOutputTool
 					result.DirectRawOutput = event.DirectRawOutput
 				case app.EventFailed:
@@ -104,7 +125,14 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 
 			response := result.Response
 
-			if printFlag, err := flags.GetBool("print"); printFlag && err == nil {
+			if printedStreamedToolOutput && result.DirectRawOutput {
+				response = ""
+			}
+
+			if printFlag && response != "" {
+				if printedStreamedToolOutput && !lastStreamChunkEndedWithNewline {
+					cmd.Print("\n")
+				}
 				plain, _ := flags.GetBool("plain")
 				cmd.Print(formatTaskOutput(app.TaskResult{
 					Response:        response,

--- a/internal/commands/task_cmd_test.go
+++ b/internal/commands/task_cmd_test.go
@@ -133,6 +133,60 @@ func TestTaskCommandHandlesInteractiveEvents(t *testing.T) {
 	assert.Contains(t, output.String(), "done")
 }
 
+func TestTaskCommandStreamedOutput(t *testing.T) {
+	t.Run("suppresses streamed output when print disabled", func(t *testing.T) {
+		output := runTaskCommandWithEvents(t, []string{"--print=false", "inspect", "repo"}, func(req app.TaskRequest) []app.Event {
+			return []app.Event{
+				{Type: app.EventOutputDelta, Text: "live output"},
+				{Type: app.EventCompleted, FinalOutput: "done", Status: req.Message},
+			}
+		})
+
+		assert.Empty(t, output)
+	})
+
+	t.Run("separates streamed output from final response", func(t *testing.T) {
+		output := runTaskCommandWithEvents(t, []string{"--plain", "inspect", "repo"}, func(req app.TaskRequest) []app.Event {
+			return []app.Event{
+				{Type: app.EventOutputDelta, Text: "live output"},
+				{Type: app.EventCompleted, FinalOutput: "done", Status: req.Message},
+			}
+		})
+
+		assert.Equal(t, "live output\ndone", output)
+	})
+}
+
+func runTaskCommandWithEvents(t *testing.T, args []string, events func(app.TaskRequest) []app.Event) string {
+	t.Helper()
+	originalNewService := newService
+	defer func() { newService = originalNewService }()
+
+	newService = func() app.Service {
+		return &fakeTaskService{events: func(_ context.Context, req app.TaskRequest) (<-chan app.Event, error) {
+			ch := make(chan app.Event)
+			go func() {
+				defer close(ch)
+				for _, event := range events(req) {
+					ch <- event
+				}
+			}()
+			return ch, nil
+		}}
+	}
+
+	cmd := NewTaskCommand(config.NewDefaultConfig())
+	output := &bytes.Buffer{}
+	cmd.SetIn(bytes.NewBufferString(""))
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+	cmd.Flags().String("device", "", "")
+	cmd.SetArgs(args)
+
+	require.NoError(t, cmd.ExecuteContext(context.Background()))
+	return output.String()
+}
+
 // runTaskCommandCapture runs the task command with the given config and args,
 // returning the TaskRequest the service received.
 func runTaskCommandCapture(t *testing.T, cfg config.Config, args ...string) app.TaskRequest {

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -1,16 +1,20 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
+	"sync"
 
 	log "github.com/laszukdawid/terminal-agent/internal/utils"
 )
 
 type BashExecutor struct {
 	workDir string
+	output  io.Writer
 }
 
 func (b *BashExecutor) Exec(code string) (string, error) {
@@ -31,8 +35,7 @@ func (b *BashExecutor) ExecContext(ctx context.Context, code string) (string, er
 		cmd.Dir = b.workDir
 	}
 
-	// Gather cmd results
-	output, err := cmd.CombinedOutput()
+	output, err := runCombinedOutput(cmd, b.output)
 	strOutput := string(output)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -42,4 +45,40 @@ func (b *BashExecutor) ExecContext(ctx context.Context, code string) (string, er
 	}
 
 	return strings.TrimSpace(strOutput), nil
+}
+
+type combinedOutputWriter struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	stream io.Writer
+}
+
+func (w *combinedOutputWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if _, err := w.buf.Write(p); err != nil {
+		return 0, err
+	}
+	if w.stream != nil {
+		if _, err := w.stream.Write(p); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+func runCombinedOutput(cmd *exec.Cmd, stream io.Writer) ([]byte, error) {
+	writer := &combinedOutputWriter{stream: stream}
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	err := cmd.Start()
+	if err != nil {
+		return writer.buf.Bytes(), err
+	}
+	if processWriter, ok := stream.(ProcessesStartedWriter); ok && cmd.Process != nil {
+		processWriter.ProcessStarted(cmd.Process.Pid)
+	}
+	err = cmd.Wait()
+	return writer.buf.Bytes(), err
 }

--- a/internal/tools/python.go
+++ b/internal/tools/python.go
@@ -152,7 +152,7 @@ func (t *PythonTool) RunSchemaWithContext(input map[string]any, ctx ToolExecutio
 
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Dir = normalizedCtx.CurrentDir
-	output, err := cmd.CombinedOutput()
+	output, err := runCombinedOutput(cmd, ctx.Output)
 	if err != nil {
 		return string(output), fmt.Errorf("python execution failed: %w", err)
 	}

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -1,6 +1,9 @@
 package tools
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 type Tool interface {
 
@@ -50,9 +53,21 @@ type CategorizedTool interface {
 	PermissionCategory() PermissionCategory
 }
 
+// ProcessesStartedWriter is an optional live-output sink extension for tools that
+// launch local processes. It lets callers correlate streamed output or display
+// warnings with the OS process that is still running.
+type ProcessesStartedWriter interface {
+	io.Writer
+	ProcessStarted(pid int)
+}
+
 type ToolExecutionContext struct {
 	RootDir    string
 	CurrentDir string
+	// Output is an optional live, user-facing output sink. Tools should still
+	// return their captured result for agent reasoning; Output is only for
+	// incremental display and may be ignored by tools without useful live output.
+	Output io.Writer
 }
 
 type ContextualTool interface {

--- a/internal/tools/unix.go
+++ b/internal/tools/unix.go
@@ -186,8 +186,14 @@ func (u *UnixTool) RunSchemaContext(ctx context.Context, input map[string]any, e
 	}
 
 	executor := u.executor
-	if execCtx.CurrentDir != "" {
-		executor = &BashExecutor{workDir: execCtx.CurrentDir}
+	if execCtx.CurrentDir != "" || execCtx.Output != nil {
+		workDir := execCtx.CurrentDir
+		if workDir == "" {
+			if bashExecutor, ok := u.executor.(*BashExecutor); ok {
+				workDir = bashExecutor.workDir
+			}
+		}
+		executor = &BashExecutor{workDir: workDir, output: execCtx.Output}
 	}
 	return u.execCodeWithExecutorContext(ctx, cmd, executor)
 }

--- a/internal/tools/unix_test.go
+++ b/internal/tools/unix_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/laszukdawid/terminal-agent/internal/utils"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,12 @@ import (
 )
 
 type mockBashExecutor struct {
+}
+
+type testOutputWriter func([]byte) (int, error)
+
+func (w testOutputWriter) Write(p []byte) (int, error) {
+	return w(p)
 }
 
 func (m *mockBashExecutor) Exec(code string) (string, error) {
@@ -89,4 +96,43 @@ func TestUnixToolDoesNotPrintExecutionInternals(t *testing.T) {
 	printed, readErr := io.ReadAll(r)
 	assert.NoError(t, readErr)
 	assert.Empty(t, string(printed))
+}
+
+func TestBashExecutor(t *testing.T) {
+	t.Run("streams output before command completes", func(t *testing.T) {
+		chunks := make(chan string, 4)
+		executor := &BashExecutor{output: testOutputWriter(func(p []byte) (int, error) {
+			chunks <- string(p)
+			return len(p), nil
+		})}
+		done := make(chan struct {
+			output string
+			err    error
+		}, 1)
+
+		go func() {
+			output, err := executor.Exec(`printf first; sleep 0.2; printf second`)
+			done <- struct {
+				output string
+				err    error
+			}{output: output, err: err}
+		}()
+
+		select {
+		case chunk := <-chunks:
+			assert.Equal(t, "first", chunk)
+		case <-done:
+			t.Fatal("command completed before streaming first output chunk")
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for streamed output")
+		}
+
+		select {
+		case result := <-done:
+			assert.NoError(t, result.err)
+			assert.Equal(t, "firstsecond", result.output)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for command completion")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- stream task tool stdout/stderr as live task events with process ids
- respect task --print=false for live and final output
- split task orchestration helpers and document live output semantics

## Tests
- go test ./...