### PR TITLE
Split OpenAI and Codex providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ $ agent config set anthropic.claude-3-haiku-20240307-v1:0
 
 ### OpenAI
 
-OpenAI supports two authentication methods:
+The `openai` provider uses API-key authentication for OpenAI API services. Use the separate `codex` provider for OAuth-backed ChatGPT/Codex access.
 
 **Option 1: API key** (traditional)
 Set the key as an environment variable:
@@ -184,15 +184,11 @@ Set the key as an environment variable:
 export OPENAI_API_KEY=your_api_key_here
 ```
 
-**Option 2: Stored credentials** (recommended)
-Use the `agent auth` command to store your API key or authenticate with your ChatGPT account:
+**Option 2: Stored API key**
+Use the `agent auth` command to store your API key:
 ```sh
-agent auth login openai               # browser OAuth login
-agent auth login openai --device      # terminal-friendly device login
 agent auth login openai --api-key     # store an API key
 ```
-
-If the browser callback does not return automatically, the browser login flow also accepts a pasted authorization code or full redirect URL as a fallback.
 
 Setting `openai` provider with `gpt-4o-mini` model can be done with `task run:set:openai` or directly
 
@@ -208,6 +204,28 @@ agent auth status openai
 ```
 
 See `agent auth --help` for more authentication options.
+
+### Codex
+
+The `codex` provider uses OAuth-backed ChatGPT/Codex access:
+
+```sh
+agent auth login codex               # browser OAuth login
+agent auth login codex --device      # terminal-friendly device login
+```
+
+If the browser callback does not return automatically, the browser login flow also accepts a pasted authorization code or full redirect URL as a fallback.
+
+```sh
+$ agent config set provider codex
+$ agent config set model gpt-4o-mini
+```
+
+Check the current Codex auth state with:
+
+```sh
+agent auth status codex
+```
 
 ### Xiaomi MiMo
 

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -2,7 +2,7 @@
 
 The `auth` command manages provider credentials. It stores API keys and OAuth tokens separately from the main config file, in `~/.config/terminal-agent/auth.json`.
 
-Currently, only the `openai` provider is supported.
+Currently, `openai` API-key auth and `codex` OAuth auth are supported.
 
 ## Usage
 
@@ -17,13 +17,13 @@ agent auth <subcommand> [args]
 Authenticate with a provider:
 
 ```sh
-agent auth login openai
-agent auth login openai --device
+agent auth login codex
+agent auth login codex --device
 agent auth login openai --api-key
 ```
 
-- `agent auth login openai` starts the browser OAuth flow. Opens the system browser by default, then listens on a local callback server to receive the authorization code.
-- `agent auth login openai --device` starts the terminal-friendly device-code flow. Prints a URL and a one-time code to paste in your browser. Polls for authorization for up to 15 minutes (5 second default interval).
+- `agent auth login codex` starts the browser OAuth flow. Opens the system browser by default, then listens on a local callback server to receive the authorization code.
+- `agent auth login codex --device` starts the terminal-friendly device-code flow. Prints a URL and a one-time code to paste in your browser. Polls for authorization for up to 15 minutes (5 second default interval).
 - `agent auth login openai --api-key` stores an API key without using OAuth.
 
 Browser login supports a pasted-code fallback. If the localhost callback does not complete automatically, paste either:
@@ -52,6 +52,7 @@ Show auth status for a provider:
 
 ```sh
 agent auth status openai
+agent auth status codex
 ```
 
 Example output:
@@ -66,7 +67,7 @@ Source: stored
 
 If `OPENAI_API_KEY` is set in the environment, `Source` will show `environment` instead.
 
-For OAuth logins, status also shows `Account ID`, `Plan type`, `Expires`, and `Expired` when that metadata is available.
+For Codex OAuth logins, status also shows `Account ID`, `Plan type`, `Expires`, and `Expired` when that metadata is available.
 
 ### logout
 
@@ -74,6 +75,7 @@ Remove stored credentials for a provider:
 
 ```sh
 agent auth logout openai
+agent auth logout codex
 ```
 
 This removes the entry from `~/.config/terminal-agent/auth.json`. It does not unset environment variables.
@@ -88,15 +90,14 @@ Credentials are stored in:
 
 The file is created with `0600` permissions and uses atomic writes (write to temp file, sync, rename) to avoid data corruption. File operations are protected by advisory file locks to prevent corruption from concurrent `agent auth` processes.
 
-For stored OAuth logins, Terminal Agent refreshes access tokens automatically while a valid refresh token is still present. If a refresh fails (e.g., the refresh token expired), you will need to run `agent auth login openai` again.
+For stored Codex OAuth logins, Terminal Agent refreshes access tokens automatically while a valid refresh token is still present. If a refresh fails (e.g., the refresh token expired), you will need to run `agent auth login codex` again.
 
 ## Auth Resolution
 
-When the agent needs an OpenAI credential at runtime, it resolves in this order:
+When the agent uses the `openai` provider, it resolves API-key credentials in this order:
 
 1. `OPENAI_API_KEY` environment variable — highest priority
 2. Stored API key in `auth.json`
-3. Stored OAuth credential in `auth.json`
-4. Error: authentication not configured
+3. Error: authentication not configured
 
-This means you can have stored credentials as a default and temporarily override them by setting `OPENAI_API_KEY`.
+When the agent uses the `codex` provider, it uses stored OAuth credentials from `auth.json`. Legacy OAuth credentials previously stored under `openai` are migrated to `codex` automatically on successful use.

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -38,7 +38,7 @@ agent config set <key> <value>
 
 | Key | Description | Example Values |
 |-----|-------------|---------------|
-| `provider` | The LLM provider to use | `openai`, `anthropic`, `bedrock`, `google`, `ollama`, `llama` |
+| `provider` | The LLM provider to use | `openai`, `codex`, `anthropic`, `bedrock`, `google`, `ollama`, `llama` |
 | `model` | The model ID to use | `gpt-4o-mini`, `claude-3-haiku-20240307`, etc. |
 | `device` | Runtime device preference for direct `llama` provider | `auto`, `cpu`, `gpu` |
 | `mcp-path` | Path to MCP JSON file | `/path/to/mcp.json` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,7 +182,8 @@ Stored credentials are managed with the `agent auth` command and take effect aut
 
 | Provider | Environment Variable | Auth File | Description |
 |----------|---------------------|-----------|-------------|
-| OpenAI | `OPENAI_API_KEY` | supported | API key or stored credential for OpenAI services |
+| OpenAI | `OPENAI_API_KEY` | supported | API key for OpenAI API services |
+| Codex | — | supported | OAuth login for ChatGPT/Codex services |
 | Anthropic | `ANTHROPIC_API_KEY` | — | API key for Anthropic Claude models |
 | Google | `GEMINI_API_KEY` | — | API key for Google AI (Gemini) |
 | Xiaomi MiMo | `MIMO_API_KEY` | — | API key for Xiaomi MiMo models |
@@ -203,14 +204,16 @@ Example of storing an API key with the auth command:
 agent auth login openai --api-key
 ```
 
-Example of using OAuth-based login instead:
+Example of using OAuth-based Codex login instead:
 
 ```sh
-agent auth login openai          # browser OAuth login
-agent auth login openai --device # device-code login
+agent auth login codex          # browser OAuth login
+agent auth login codex --device # device-code login
 ```
 
-**Auth resolution order for OpenAI:** `OPENAI_API_KEY` env var → stored API key in auth.json → stored OAuth credential → error.
+**Auth resolution order for OpenAI:** `OPENAI_API_KEY` env var → stored API key in auth.json → error.
+
+**Auth resolution for Codex:** stored OAuth credential in auth.json → legacy OpenAI OAuth credential migration → error.
 
 For the `llama` provider, example runtime setup is:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,7 +76,7 @@ Inside the popup:
 Before using Terminal Agent, you'll need to configure it with your preferred LLM provider:
 
 ```sh
-# Set your provider (e.g., "openai", "anthropic", "bedrock", "google", "ollama", "llama")
+# Set your provider (e.g., "openai", "codex", "anthropic", "bedrock", "google", "ollama", "llama")
 agent config set provider openai
 
 # Set your preferred model

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -80,7 +80,7 @@ Example config:
 
 ### OpenAI
 
-OpenAI supports two methods to set up authentication: an API key (traditional), or stored credentials via `agent auth`.
+The `openai` provider uses API-key authentication for OpenAI API services. Use the separate `codex` provider for OAuth-backed ChatGPT/Codex access.
 
 **Option 1: API key via environment variable**
 
@@ -91,18 +91,14 @@ OpenAI supports two methods to set up authentication: an API key (traditional), 
    export OPENAI_API_KEY=your_api_key_here
    ```
 
-**Option 2: Stored credentials via agent auth**
+**Option 2: Stored API key via agent auth**
 
-Store your API key or authenticate with your ChatGPT subscription:
+Store your API key:
 ```sh
-agent auth login openai               # browser OAuth login
-agent auth login openai --device      # terminal-friendly device login
-agent auth login openai --api-key     # store an API key
+agent auth login openai --api-key
 ```
 
-Credentials are persisted in `~/.config/terminal-agent/auth.json`. They are used automatically for `ask`, `chat`, and `task` commands when no `OPENAI_API_KEY` environment variable is present. Stored OAuth tokens refresh automatically while a valid refresh token is still available.
-
-If the browser callback does not complete automatically, `agent auth login openai` also accepts a pasted authorization code or full redirect URL as a fallback.
+Credentials are persisted in `~/.config/terminal-agent/auth.json`. They are used automatically for `ask`, `chat`, and `task` commands when no `OPENAI_API_KEY` environment variable is present.
 
 Check your auth status at any time:
 ```sh
@@ -136,7 +132,37 @@ export OPENAI_BASE_URL=https://your-custom-endpoint.com/v1
 - Tool usage capability for the `task` command
 - Compatible with OpenAI-compatible endpoints via `OPENAI_BASE_URL`
 
-**Auth resolution order:** When both a stored credential and `OPENAI_API_KEY` exist, the environment variable takes precedence.
+**Auth resolution order:** When both a stored OpenAI API key and `OPENAI_API_KEY` exist, the environment variable takes precedence.
+
+### Codex
+
+The `codex` provider uses OAuth-backed ChatGPT/Codex access through `agent auth`.
+
+Authenticate with your ChatGPT subscription:
+```sh
+agent auth login codex               # browser OAuth login
+agent auth login codex --device      # terminal-friendly device login
+```
+
+Stored OAuth tokens refresh automatically while a valid refresh token is still available. If the browser callback does not complete automatically, `agent auth login codex` also accepts a pasted authorization code or full redirect URL as a fallback.
+
+Check your auth status at any time:
+```sh
+agent auth status codex
+```
+
+Remove stored credentials:
+```sh
+agent auth logout codex
+```
+
+**Configuration:**
+```sh
+agent config set provider codex
+agent config set model gpt-4o-mini
+```
+
+Legacy OAuth credentials previously stored under `openai` are migrated to `codex` automatically on successful use.
 
 ### Xiaomi MiMo
 

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -9,11 +9,12 @@ import (
 )
 
 var (
-	ErrAuthNotConfigured     = errors.New("OpenAI authentication not configured. Set OPENAI_API_KEY or run 'agent auth login openai --api-key'.")
-	ErrOpenAIOAuthConfigured = errors.New("Stored OpenAI OAuth login is configured. This code path only supports API-key auth resolution.")
-	ErrOpenAIOAuthExpired    = errors.New("Stored OpenAI OAuth login could not be refreshed. Run 'agent auth login openai' again.")
-	ErrUnsupportedCredential = errors.New("unsupported stored auth credential")
-	ErrUnsupportedProvider   = errors.New("unsupported auth provider")
+	ErrAuthNotConfigured      = errors.New("OpenAI authentication not configured. Set OPENAI_API_KEY or run 'agent auth login openai --api-key'.")
+	ErrCodexAuthNotConfigured = errors.New("Codex authentication not configured. Run 'agent auth login codex'.")
+	ErrOpenAIOAuthConfigured  = errors.New("Stored OpenAI OAuth login is configured. Use the codex provider for OAuth authentication.")
+	ErrOpenAIOAuthExpired     = errors.New("Stored Codex OAuth login could not be refreshed. Run 'agent auth login codex' again.")
+	ErrUnsupportedCredential  = errors.New("unsupported stored auth credential")
+	ErrUnsupportedProvider    = errors.New("unsupported auth provider")
 )
 
 func NormalizeProvider(provider string) string {
@@ -21,15 +22,20 @@ func NormalizeProvider(provider string) string {
 }
 
 func ValidateProvider(provider string) error {
-	if NormalizeProvider(provider) != ProviderOpenAI {
+	switch NormalizeProvider(provider) {
+	case ProviderOpenAI, ProviderCodex:
+		return nil
+	default:
 		return fmt.Errorf("%w: %s", ErrUnsupportedProvider, provider)
 	}
-	return nil
 }
 
 func (m *Manager) SaveAPIKey(provider, key string) error {
 	if err := ValidateProvider(provider); err != nil {
 		return err
+	}
+	if NormalizeProvider(provider) != ProviderOpenAI {
+		return fmt.Errorf("%s does not support API-key auth; use 'agent auth login openai --api-key'", provider)
 	}
 
 	trimmed := strings.TrimSpace(key)
@@ -53,8 +59,11 @@ func (m *Manager) Status(provider string) (Status, error) {
 		Path:     m.path,
 	}
 
-	credential, source, configured, err := m.lookupOpenAICredential()
+	credential, source, configured, err := m.lookupCredentialForProvider(NormalizeProvider(provider))
 	if err != nil {
+		if errors.Is(err, ErrOpenAIOAuthConfigured) {
+			return status, nil
+		}
 		return Status{}, err
 	}
 	if !configured {
@@ -76,43 +85,42 @@ func (m *Manager) Status(provider string) (Status, error) {
 }
 
 func (m *Manager) ResolveOpenAIAPIKeyAuth() (ResolvedAuth, error) {
-	credential, _, configured, err := m.lookupOpenAICredential()
+	credential, source, configured, err := m.lookupOpenAIAPIKeyCredential()
 	if err != nil {
 		return ResolvedAuth{}, err
 	}
-	if configured && credential.Type == CredentialTypeOAuth {
-		return ResolvedAuth{}, ErrOpenAIOAuthConfigured
+	if !configured || strings.TrimSpace(credential.Key) == "" {
+		return ResolvedAuth{}, ErrAuthNotConfigured
 	}
-	return m.ResolveOpenAIAuth()
+	return ResolvedAuth{
+		Provider: ProviderOpenAI,
+		Type:     CredentialTypeAPIKey,
+		Source:   source,
+		Token:    credential.Key,
+	}, nil
 }
 
 func (m *Manager) ResolveOpenAIAuth() (ResolvedAuth, error) {
-	credential, source, configured, err := m.lookupOpenAICredential()
+	return m.ResolveOpenAIAPIKeyAuth()
+}
+
+func (m *Manager) ResolveCodexAuth() (ResolvedAuth, error) {
+	credential, source, configured, err := m.lookupCodexOAuthCredential()
 	if err != nil {
 		return ResolvedAuth{}, err
 	}
 	if !configured {
-		return ResolvedAuth{}, ErrAuthNotConfigured
+		return ResolvedAuth{}, ErrCodexAuthNotConfigured
 	}
 
 	switch credential.Type {
-	case CredentialTypeAPIKey:
-		if strings.TrimSpace(credential.Key) == "" {
-			return ResolvedAuth{}, ErrAuthNotConfigured
-		}
-		return ResolvedAuth{
-			Provider: ProviderOpenAI,
-			Type:     CredentialTypeAPIKey,
-			Source:   source,
-			Token:    credential.Key,
-		}, nil
 	case CredentialTypeOAuth:
-		refreshedCredential, _, err := m.refreshOpenAIOAuthIfNeeded()
+		refreshedCredential, _, err := m.refreshCodexOAuthIfNeeded()
 		if err != nil {
 			return ResolvedAuth{}, err
 		}
 		if strings.TrimSpace(refreshedCredential.Access) == "" {
-			return ResolvedAuth{}, ErrAuthNotConfigured
+			return ResolvedAuth{}, ErrCodexAuthNotConfigured
 		}
 		expiresAt := time.Time{}
 		expired := false
@@ -121,10 +129,10 @@ func (m *Manager) ResolveOpenAIAuth() (ResolvedAuth, error) {
 			expired = openAIOAuthNeedsRefresh(refreshedCredential, time.Now())
 		}
 		if strings.TrimSpace(refreshedCredential.AccountID) == "" {
-			return ResolvedAuth{}, fmt.Errorf("stored OpenAI OAuth credential is missing account metadata; run 'agent auth login openai' again")
+			return ResolvedAuth{}, fmt.Errorf("stored Codex OAuth credential is missing account metadata; run 'agent auth login codex' again")
 		}
 		return ResolvedAuth{
-			Provider:  ProviderOpenAI,
+			Provider:  ProviderCodex,
 			Type:      CredentialTypeOAuth,
 			Source:    source,
 			Token:     refreshedCredential.Access,
@@ -138,15 +146,21 @@ func (m *Manager) ResolveOpenAIAuth() (ResolvedAuth, error) {
 	}
 }
 
-func (m *Manager) lookupOpenAICredential() (Credential, string, bool, error) {
+func (m *Manager) lookupCredentialForProvider(provider string) (Credential, string, bool, error) {
+	switch provider {
+	case ProviderOpenAI:
+		return m.lookupOpenAIAPIKeyCredential()
+	case ProviderCodex:
+		return m.lookupCodexOAuthCredential()
+	default:
+		return Credential{}, "", false, fmt.Errorf("%w: %s", ErrUnsupportedProvider, provider)
+	}
+}
+
+func (m *Manager) lookupOpenAIAPIKeyCredential() (Credential, string, bool, error) {
 	authFile, err := m.Load()
 	if err != nil {
 		return Credential{}, "", false, err
-	}
-
-	credential, exists := authFile[ProviderOpenAI]
-	if exists && credential.Type == CredentialTypeOAuth {
-		return credential, SourceStored, true, nil
 	}
 
 	if envKey := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); envKey != "" {
@@ -156,7 +170,29 @@ func (m *Manager) lookupOpenAICredential() (Credential, string, bool, error) {
 		}, SourceEnvironment, true, nil
 	}
 
+	credential, exists := authFile[ProviderOpenAI]
 	if exists {
+		if credential.Type == CredentialTypeOAuth {
+			return Credential{}, "", false, ErrOpenAIOAuthConfigured
+		}
+		return credential, SourceStored, true, nil
+	}
+
+	return Credential{}, "", false, nil
+}
+
+func (m *Manager) lookupCodexOAuthCredential() (Credential, string, bool, error) {
+	authFile, err := m.Load()
+	if err != nil {
+		return Credential{}, "", false, err
+	}
+
+	if credential, exists := authFile[ProviderCodex]; exists {
+		return credential, SourceStored, true, nil
+	}
+
+	credential, exists := authFile[ProviderOpenAI]
+	if exists && credential.Type == CredentialTypeOAuth {
 		return credential, SourceStored, true, nil
 	}
 

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -111,9 +111,9 @@ func TestResolveOpenAIAPIKeyAuthReturnsOAuthNotSupported(t *testing.T) {
 	}
 }
 
-func TestResolveOpenAIAuthReturnsStoredOAuth(t *testing.T) {
+func TestResolveCodexAuthReturnsStoredOAuth(t *testing.T) {
 	mgr := newTestManager(t)
-	if err := mgr.SaveProvider(ProviderOpenAI, Credential{
+	if err := mgr.SaveProvider(ProviderCodex, Credential{
 		Type:      CredentialTypeOAuth,
 		Access:    "access-token",
 		Refresh:   "refresh-token",
@@ -124,21 +124,24 @@ func TestResolveOpenAIAuthReturnsStoredOAuth(t *testing.T) {
 		t.Fatalf("SaveProvider() error = %v", err)
 	}
 
-	resolved, err := mgr.ResolveOpenAIAuth()
+	resolved, err := mgr.ResolveCodexAuth()
 	if err != nil {
-		t.Fatalf("ResolveOpenAIAuth() error = %v", err)
+		t.Fatalf("ResolveCodexAuth() error = %v", err)
 	}
 	if resolved.Type != CredentialTypeOAuth {
 		t.Fatalf("resolved.Type = %q, want %q", resolved.Type, CredentialTypeOAuth)
+	}
+	if resolved.Provider != ProviderCodex {
+		t.Fatalf("resolved.Provider = %q, want %q", resolved.Provider, ProviderCodex)
 	}
 	if resolved.AccountID != "workspace-1" {
 		t.Fatalf("resolved.AccountID = %q, want %q", resolved.AccountID, "workspace-1")
 	}
 }
 
-func TestResolveOpenAIAuthPrefersStoredOAuthOverEnvironment(t *testing.T) {
+func TestResolveOpenAIAuthIgnoresCodexOAuthAndUsesEnvironment(t *testing.T) {
 	mgr := newTestManager(t)
-	if err := mgr.SaveProvider(ProviderOpenAI, Credential{
+	if err := mgr.SaveProvider(ProviderCodex, Credential{
 		Type:      CredentialTypeOAuth,
 		Access:    "access-token",
 		Refresh:   "refresh-token",
@@ -154,6 +157,35 @@ func TestResolveOpenAIAuthPrefersStoredOAuthOverEnvironment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveOpenAIAuth() error = %v", err)
 	}
+	if resolved.Type != CredentialTypeAPIKey {
+		t.Fatalf("resolved.Type = %q, want %q", resolved.Type, CredentialTypeAPIKey)
+	}
+	if resolved.Source != SourceEnvironment {
+		t.Fatalf("resolved.Source = %q, want %q", resolved.Source, SourceEnvironment)
+	}
+	if resolved.Token != "sk-env" {
+		t.Fatalf("resolved.Token = %q, want environment API key", resolved.Token)
+	}
+}
+
+func TestResolveCodexAuthIgnoresEnvironmentAPIKey(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := mgr.SaveProvider(ProviderCodex, Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    "access-token",
+		Refresh:   "refresh-token",
+		Expires:   time.Now().Add(time.Hour).UnixMilli(),
+		AccountID: "workspace-1",
+	}); err != nil {
+		t.Fatalf("SaveProvider() error = %v", err)
+	}
+
+	t.Setenv("OPENAI_API_KEY", "sk-env")
+
+	resolved, err := mgr.ResolveCodexAuth()
+	if err != nil {
+		t.Fatalf("ResolveCodexAuth() error = %v", err)
+	}
 	if resolved.Type != CredentialTypeOAuth {
 		t.Fatalf("resolved.Type = %q, want %q", resolved.Type, CredentialTypeOAuth)
 	}
@@ -165,9 +197,9 @@ func TestResolveOpenAIAuthPrefersStoredOAuthOverEnvironment(t *testing.T) {
 	}
 }
 
-func TestResolveOpenAIAuthRejectsExpiredStoredOAuth(t *testing.T) {
+func TestResolveCodexAuthRejectsExpiredStoredOAuth(t *testing.T) {
 	mgr := newTestManager(t)
-	if err := mgr.SaveProvider(ProviderOpenAI, Credential{
+	if err := mgr.SaveProvider(ProviderCodex, Credential{
 		Type:      CredentialTypeOAuth,
 		Access:    "access-token",
 		Refresh:   "refresh-token",
@@ -181,9 +213,40 @@ func TestResolveOpenAIAuthRejectsExpiredStoredOAuth(t *testing.T) {
 	openAITokenEndpoint = "http://127.0.0.1:1"
 	defer func() { openAITokenEndpoint = originalTokenEndpoint }()
 
-	_, err := mgr.ResolveOpenAIAuth()
+	_, err := mgr.ResolveCodexAuth()
 	if err == nil {
 		t.Fatal("expected refresh failure for expired stored OAuth")
+	}
+}
+
+func TestResolveCodexAuthMigratesLegacyOpenAIOAuth(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := mgr.SaveProvider(ProviderOpenAI, Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    "access-token",
+		Refresh:   "refresh-token",
+		Expires:   time.Now().Add(time.Hour).UnixMilli(),
+		AccountID: "workspace-1",
+	}); err != nil {
+		t.Fatalf("SaveProvider() error = %v", err)
+	}
+
+	resolved, err := mgr.ResolveCodexAuth()
+	if err != nil {
+		t.Fatalf("ResolveCodexAuth() error = %v", err)
+	}
+	if resolved.Token != "access-token" {
+		t.Fatalf("resolved.Token = %q, want legacy access token", resolved.Token)
+	}
+	authFile, err := mgr.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if _, exists := authFile[ProviderOpenAI]; exists {
+		t.Fatal("expected legacy OpenAI OAuth credential to be removed")
+	}
+	if _, exists := authFile[ProviderCodex]; !exists {
+		t.Fatal("expected Codex credential to be written")
 	}
 }
 
@@ -207,6 +270,35 @@ func TestDeleteProvider(t *testing.T) {
 	}
 	if status.Configured {
 		t.Fatalf("expected provider to be unconfigured after delete, got %#v", status)
+	}
+}
+
+func TestDeleteCodexProviderRemovesLegacyOpenAIOAuth(t *testing.T) {
+	mgr := newTestManager(t)
+	if err := mgr.SaveProvider(ProviderOpenAI, Credential{
+		Type:      CredentialTypeOAuth,
+		Access:    "access-token",
+		Refresh:   "refresh-token",
+		Expires:   time.Now().Add(time.Hour).UnixMilli(),
+		AccountID: "workspace-1",
+	}); err != nil {
+		t.Fatalf("SaveProvider() error = %v", err)
+	}
+
+	deleted, err := mgr.DeleteProvider(ProviderCodex)
+	if err != nil {
+		t.Fatalf("DeleteProvider() error = %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected legacy Codex credential to be deleted")
+	}
+
+	authFile, err := mgr.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if _, exists := authFile[ProviderOpenAI]; exists {
+		t.Fatal("expected legacy OpenAI OAuth credential to be removed")
 	}
 }
 

--- a/internal/auth/openai_browser.go
+++ b/internal/auth/openai_browser.go
@@ -129,7 +129,7 @@ func (m *Manager) LoginOpenAIBrowser(cfg BrowserLoginConfig) (*OAuthResult, erro
 
 	expiresAt := time.Now().UnixMilli() + result.ExpiresIn*1000
 
-	if err := m.SaveProvider(ProviderOpenAI, Credential{
+	if err := m.SaveProvider(ProviderCodex, Credential{
 		Type:      CredentialTypeOAuth,
 		Access:    result.AccessToken,
 		Refresh:   result.RefreshToken,

--- a/internal/auth/openai_device.go
+++ b/internal/auth/openai_device.go
@@ -108,7 +108,7 @@ func (m *Manager) LoginOpenAIDevice(cfg BrowserLoginConfig) (*OAuthResult, error
 
 	expiresAt := time.Now().UnixMilli() + result.ExpiresIn*1000
 
-	if err := m.SaveProvider(ProviderOpenAI, Credential{
+	if err := m.SaveProvider(ProviderCodex, Credential{
 		Type:      CredentialTypeOAuth,
 		Access:    result.AccessToken,
 		Refresh:   result.RefreshToken,

--- a/internal/auth/openai_refresh.go
+++ b/internal/auth/openai_refresh.go
@@ -11,6 +11,14 @@ import (
 )
 
 func (m *Manager) refreshOpenAIOAuthIfNeeded() (Credential, bool, error) {
+	return m.refreshOAuthIfNeeded(ProviderOpenAI)
+}
+
+func (m *Manager) refreshCodexOAuthIfNeeded() (Credential, bool, error) {
+	return m.refreshOAuthIfNeeded(ProviderCodex)
+}
+
+func (m *Manager) refreshOAuthIfNeeded(provider string) (Credential, bool, error) {
 	var refreshed bool
 	var resolved Credential
 	err := m.withLock(func() error {
@@ -19,7 +27,12 @@ func (m *Manager) refreshOpenAIOAuthIfNeeded() (Credential, bool, error) {
 			return err
 		}
 
-		credential, exists := authFile[ProviderOpenAI]
+		credential, exists := authFile[provider]
+		legacyCodexCredential := false
+		if !exists && provider == ProviderCodex {
+			credential, exists = authFile[ProviderOpenAI]
+			legacyCodexCredential = exists && credential.Type == CredentialTypeOAuth
+		}
 		if !exists {
 			return ErrAuthNotConfigured
 		}
@@ -29,6 +42,13 @@ func (m *Manager) refreshOpenAIOAuthIfNeeded() (Credential, bool, error) {
 		}
 
 		if !openAIOAuthNeedsRefresh(credential, time.Now()) {
+			if legacyCodexCredential {
+				authFile[ProviderCodex] = credential
+				delete(authFile, ProviderOpenAI)
+				if err := m.saveUnlocked(authFile); err != nil {
+					return err
+				}
+			}
 			resolved = credential
 			return nil
 		}
@@ -41,7 +61,12 @@ func (m *Manager) refreshOpenAIOAuthIfNeeded() (Credential, bool, error) {
 			return err
 		}
 
-		authFile[ProviderOpenAI] = updated
+		authFile[provider] = updated
+		if provider == ProviderCodex {
+			if legacy, exists := authFile[ProviderOpenAI]; exists && legacy.Type == CredentialTypeOAuth {
+				delete(authFile, ProviderOpenAI)
+			}
+		}
 		if err := m.saveUnlocked(authFile); err != nil {
 			return err
 		}

--- a/internal/auth/openai_refresh_test.go
+++ b/internal/auth/openai_refresh_test.go
@@ -62,7 +62,7 @@ func TestRefreshOpenAIOAuthCredentialSuccess(t *testing.T) {
 	}
 }
 
-func TestResolveOpenAIAuthRefreshesNearExpiryAndPersists(t *testing.T) {
+func TestResolveCodexAuthRefreshesNearExpiryAndPersists(t *testing.T) {
 	manager := newTestManager(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(OpenAITokenResponse{
@@ -77,7 +77,7 @@ func TestResolveOpenAIAuthRefreshesNearExpiryAndPersists(t *testing.T) {
 	openAITokenEndpoint = server.URL
 	defer func() { openAITokenEndpoint = originalTokenEndpoint }()
 
-	if err := manager.SaveProvider(ProviderOpenAI, Credential{
+	if err := manager.SaveProvider(ProviderCodex, Credential{
 		Type:      CredentialTypeOAuth,
 		Access:    "old-access",
 		Refresh:   "old-refresh",
@@ -88,9 +88,9 @@ func TestResolveOpenAIAuthRefreshesNearExpiryAndPersists(t *testing.T) {
 		t.Fatalf("SaveProvider() error = %v", err)
 	}
 
-	resolved, err := manager.ResolveOpenAIAuth()
+	resolved, err := manager.ResolveCodexAuth()
 	if err != nil {
-		t.Fatalf("ResolveOpenAIAuth() error = %v", err)
+		t.Fatalf("ResolveCodexAuth() error = %v", err)
 	}
 	if resolved.Token == "old-access" {
 		t.Fatal("expected refreshed access token")
@@ -103,7 +103,7 @@ func TestResolveOpenAIAuthRefreshesNearExpiryAndPersists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	stored := authFile[ProviderOpenAI]
+	stored := authFile[ProviderCodex]
 	if stored.Refresh != "rotated-refresh" {
 		t.Fatalf("stored refresh token = %q, want %q", stored.Refresh, "rotated-refresh")
 	}
@@ -112,7 +112,7 @@ func TestResolveOpenAIAuthRefreshesNearExpiryAndPersists(t *testing.T) {
 	}
 }
 
-func TestResolveOpenAIAuthRefreshFailureLeavesStoredCredentialIntact(t *testing.T) {
+func TestResolveCodexAuthRefreshFailureLeavesStoredCredentialIntact(t *testing.T) {
 	manager := newTestManager(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "nope", http.StatusUnauthorized)
@@ -131,11 +131,11 @@ func TestResolveOpenAIAuthRefreshFailureLeavesStoredCredentialIntact(t *testing.
 		AccountID: "workspace-1",
 		PlanType:  "plus",
 	}
-	if err := manager.SaveProvider(ProviderOpenAI, original); err != nil {
+	if err := manager.SaveProvider(ProviderCodex, original); err != nil {
 		t.Fatalf("SaveProvider() error = %v", err)
 	}
 
-	_, err := manager.ResolveOpenAIAuth()
+	_, err := manager.ResolveCodexAuth()
 	if err == nil {
 		t.Fatal("expected refresh failure")
 	}
@@ -144,7 +144,7 @@ func TestResolveOpenAIAuthRefreshFailureLeavesStoredCredentialIntact(t *testing.
 	if loadErr != nil {
 		t.Fatalf("Load() error = %v", loadErr)
 	}
-	stored := authFile[ProviderOpenAI]
+	stored := authFile[ProviderCodex]
 	if stored.Access != original.Access || stored.Refresh != original.Refresh || stored.AccountID != original.AccountID {
 		t.Fatalf("stored credential changed after failed refresh: %#v", stored)
 	}

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -147,11 +147,23 @@ func (m *Manager) DeleteProvider(provider string) (bool, error) {
 		}
 
 		if _, exists := authFile[provider]; !exists {
+			if provider == ProviderCodex {
+				if legacy, legacyExists := authFile[ProviderOpenAI]; legacyExists && legacy.Type == CredentialTypeOAuth {
+					delete(authFile, ProviderOpenAI)
+					deleted = true
+					return m.saveUnlocked(authFile)
+				}
+			}
 			return nil
 		}
 
 		delete(authFile, provider)
 		deleted = true
+		if provider == ProviderCodex {
+			if legacy, exists := authFile[ProviderOpenAI]; exists && legacy.Type == CredentialTypeOAuth {
+				delete(authFile, ProviderOpenAI)
+			}
+		}
 		return m.saveUnlocked(authFile)
 	})
 	if err != nil {

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -7,6 +7,7 @@ const (
 	CredentialTypeOAuth  = "oauth"
 
 	ProviderOpenAI = "openai"
+	ProviderCodex  = "codex"
 
 	SourceEnvironment = "environment"
 	SourceStored      = "stored"

--- a/internal/commands/auth_cmd.go
+++ b/internal/commands/auth_cmd.go
@@ -47,6 +47,12 @@ func authLoginCommand() *cobra.Command {
 			if device && apiKeyMode {
 				return fmt.Errorf("use only one auth mode flag")
 			}
+			if apiKeyMode && provider != auth.ProviderOpenAI {
+				return fmt.Errorf("%s does not support API-key auth; use 'agent auth login openai --api-key'", provider)
+			}
+			if !apiKeyMode && provider != auth.ProviderCodex {
+				return fmt.Errorf("%s does not support OAuth auth; use 'agent auth login codex'", provider)
+			}
 
 			manager := auth.NewManager()
 
@@ -58,7 +64,7 @@ func authLoginCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				cmd.Printf("Successfully authenticated with OpenAI.\n")
+				cmd.Printf("Successfully authenticated with Codex.\n")
 				cmd.Printf("Account ID: %s\n", result.AccountID)
 				cmd.Printf("Credentials stored in %s\n", manager.Path())
 				return nil
@@ -84,7 +90,7 @@ func authLoginCommand() *cobra.Command {
 				return err
 			}
 
-			cmd.Printf("Successfully authenticated with OpenAI.\n")
+			cmd.Printf("Successfully authenticated with Codex.\n")
 			cmd.Printf("Account ID: %s\n", result.AccountID)
 			cmd.Printf("Credentials stored in %s\n", manager.Path())
 			return nil

--- a/internal/commands/auth_cmd_test.go
+++ b/internal/commands/auth_cmd_test.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthLoginRejectsUnsupportedModeForProvider(t *testing.T) {
+	t.Run("openai rejects oauth", func(t *testing.T) {
+		cmd := NewAuthCommand()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs([]string{"login", "openai"})
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "openai does not support OAuth auth")
+	})
+
+	t.Run("codex rejects api key", func(t *testing.T) {
+		cmd := NewAuthCommand()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs([]string{"login", "codex", "--api-key", "--key", "sk-test"})
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "codex does not support API-key auth")
+	})
+}
+
+func TestAuthLoginOpenAIStoresAPIKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cmd := NewAuthCommand()
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"login", "openai", "--api-key", "--key", "sk-test"})
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Contains(t, output.String(), "Stored OpenAI API key")
+}

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -82,6 +82,7 @@ func NewDefaultConfig() *config {
 		Providers: map[string]string{
 			"anthropic": "claude-3-5-haiku-latest",
 			"bedrock":   "anthropic.claude-3-haiku-20240307-v1:0",
+			"codex":     "gpt-4o-mini",
 			"google":    "gemini-3.1-flash-lite",
 			"llama":     "llama3.2",
 			"mimo":      "mimo-v2.5-pro",

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -73,6 +73,7 @@ func TestLoadConfig(t *testing.T) {
 		// Verify that default providers included
 		assert.Equal(t, "claude-3-5-haiku-latest", config.Providers["anthropic"])
 		assert.Equal(t, "anthropic.claude-3-haiku-20240307-v1:0", config.Providers["bedrock"])
+		assert.Equal(t, "gpt-4o-mini", config.Providers["codex"])
 		assert.Equal(t, "llama3.2", config.Providers["llama"])
 		assert.Equal(t, "mimo-v2.5-pro", config.Providers["mimo"])
 		assert.Equal(t, "mistral-small-latest", config.Providers["mistral"])

--- a/internal/connector/main.go
+++ b/internal/connector/main.go
@@ -13,6 +13,8 @@ func NewConnector(provider string, modelID string, cfg config.Config) (LLMConnec
 	switch provider {
 	case BedrockProvider:
 		connector, err = NewBedrockConnector((*BedrockModelID)(&modelID))
+	case CodexProvider:
+		connector = NewCodexConnector(&modelID)
 	case OpenaiProvider:
 		connector = NewOpenAIConnector(&modelID)
 	case MiMoProvider:

--- a/internal/connector/main_test.go
+++ b/internal/connector/main_test.go
@@ -22,6 +22,13 @@ func TestNewConnectorUsesProviderDefaultModelWhenModelIDEmpty(t *testing.T) {
 	assert.IsType(t, &OpenAIConnector{}, conn)
 }
 
+func TestNewConnectorCreatesCodexConnector(t *testing.T) {
+	conn, err := NewConnector(CodexProvider, "", nil)
+
+	require.NoError(t, err)
+	assert.IsType(t, &CodexConnector{}, conn)
+}
+
 func TestNewConnectorCreatesMistralConnector(t *testing.T) {
 	t.Setenv("MISTRAL_API_KEY", "test-key")
 

--- a/internal/connector/openai.go
+++ b/internal/connector/openai.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	OpenaiProvider = "openai"
+	CodexProvider  = "codex"
 
 	DefaultOpenAIModel = openai.ChatModelGPT4oMini
 )
@@ -62,6 +63,10 @@ type OpenAIConnector struct {
 	authErr error
 }
 
+type CodexConnector struct {
+	*OpenAIConnector
+}
+
 func computePriceOpenai(modelId string, usage *openai.CompletionUsage) *LLMPrice {
 	prices, exists := ModelPricesOpenai[modelId]
 	if !exists {
@@ -101,27 +106,16 @@ func NewOpenAIConnector(modelID *string) *OpenAIConnector {
 		model := DefaultOpenAIModel
 		modelID = &model
 	}
-	manager := auth.NewManager()
-	resolvedAuth, err := manager.ResolveOpenAIAuth()
+	resolvedAuth, err := auth.NewManager().ResolveOpenAIAPIKeyAuth()
 	var authErr error
 	clientOptions := []option.RequestOption{}
 	if err != nil {
 		authErr = err
 	} else {
 		clientOptions = append(clientOptions, option.WithAPIKey(resolvedAuth.Token))
-		switch resolvedAuth.Type {
-		case auth.CredentialTypeOAuth:
-			clientOptions = append(clientOptions,
-				option.WithBaseURL(auth.OpenAICodexBaseURL),
-				option.WithHeader("ChatGPT-Account-ID", resolvedAuth.AccountID),
-				option.WithHeader("originator", auth.OpenAIOriginator()),
-				option.WithHeader("OpenAI-Beta", auth.OpenAIResponsesBetaHeader),
-			)
-		default:
-			if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
-				clientOptions = append(clientOptions, option.WithBaseURL(baseURL))
-				logger.Debug("Using custom OpenAI base URL", zap.String("baseURL", baseURL))
-			}
+		if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
+			clientOptions = append(clientOptions, option.WithBaseURL(baseURL))
+			logger.Debug("Using custom OpenAI base URL", zap.String("baseURL", baseURL))
 		}
 	}
 
@@ -136,6 +130,39 @@ func NewOpenAIConnector(modelID *string) *OpenAIConnector {
 	}
 
 	return connector
+}
+
+func NewCodexConnector(modelID *string) *CodexConnector {
+	logger := *utils.GetLogger()
+	logger.Debug("NewCodexConnector")
+
+	if modelID == nil || *modelID == "" {
+		model := DefaultOpenAIModel
+		modelID = &model
+	}
+	resolvedAuth, err := auth.NewManager().ResolveCodexAuth()
+	var authErr error
+	clientOptions := []option.RequestOption{}
+	if err != nil {
+		authErr = err
+	} else {
+		clientOptions = append(clientOptions,
+			option.WithAPIKey(resolvedAuth.Token),
+			option.WithBaseURL(auth.OpenAICodexBaseURL),
+			option.WithHeader("ChatGPT-Account-ID", resolvedAuth.AccountID),
+			option.WithHeader("originator", auth.OpenAIOriginator()),
+			option.WithHeader("OpenAI-Beta", auth.OpenAIResponsesBetaHeader),
+		)
+	}
+
+	client := openai.NewClient(clientOptions...)
+	return &CodexConnector{OpenAIConnector: &OpenAIConnector{
+		client:  &client,
+		logger:  logger,
+		modelID: *modelID,
+		auth:    resolvedAuth,
+		authErr: authErr,
+	}}
 }
 
 func (oc *OpenAIConnector) streamQuery(ctx context.Context, qParams *QueryParams, params openai.ChatCompletionNewParams) (*string, error) {
@@ -197,9 +224,6 @@ func (oc *OpenAIConnector) Query(ctx context.Context, qParams *QueryParams) (str
 	if oc.authErr != nil {
 		return "", oc.authErr
 	}
-	if oc.auth.Type == auth.CredentialTypeOAuth {
-		return oc.queryOAuth(ctx, qParams)
-	}
 
 	messages := []openai.ChatCompletionMessageParamUnion{openai.SystemMessage(*qParams.SysPrompt)}
 	for _, msg := range qParams.Messages {
@@ -248,9 +272,6 @@ func (oc *OpenAIConnector) QueryWithTool(ctx context.Context, qParams *QueryPara
 	response := LlmResponseWithTools{}
 	if oc.authErr != nil {
 		return response, oc.authErr
-	}
-	if oc.auth.Type == auth.CredentialTypeOAuth {
-		return oc.queryWithToolOAuth(ctx, qParams, tools)
 	}
 
 	oParams := openai.ChatCompletionNewParams{

--- a/internal/connector/openai_oauth.go
+++ b/internal/connector/openai_oauth.go
@@ -151,6 +151,14 @@ func (oc *OpenAIConnector) queryOAuth(ctx context.Context, qParams *QueryParams)
 	return *result, nil
 }
 
+func (cc *CodexConnector) Query(ctx context.Context, qParams *QueryParams) (string, error) {
+	oc := cc.OpenAIConnector
+	if oc.authErr != nil {
+		return "", oc.authErr
+	}
+	return oc.queryOAuth(ctx, qParams)
+}
+
 func (oc *OpenAIConnector) queryWithToolOAuth(ctx context.Context, qParams *QueryParams, tools map[string]tools.Tool) (LlmResponseWithTools, error) {
 	response := LlmResponseWithTools{}
 	params := buildResponsesParams(oc.modelID, qParams)
@@ -195,4 +203,12 @@ func (oc *OpenAIConnector) queryWithToolOAuth(ctx context.Context, qParams *Quer
 	}
 
 	return response, nil
+}
+
+func (cc *CodexConnector) QueryWithTool(ctx context.Context, qParams *QueryParams, tools map[string]tools.Tool) (LlmResponseWithTools, error) {
+	oc := cc.OpenAIConnector
+	if oc.authErr != nil {
+		return LlmResponseWithTools{}, oc.authErr
+	}
+	return oc.queryWithToolOAuth(ctx, qParams, tools)
 }

--- a/internal/connector/providers.go
+++ b/internal/connector/providers.go
@@ -16,6 +16,7 @@ var providerRegistry = []ProviderInfo{
 	{Name: AnthropicProvider, DefaultModel: DefaultAnthropicModel},
 	// BedrockModelID and ChatModel are named string types, hence the conversions.
 	{Name: BedrockProvider, DefaultModel: string(ClaudeHaiku)},
+	{Name: CodexProvider, DefaultModel: string(DefaultOpenAIModel)},
 	{Name: GoogleProvider, DefaultModel: Gemini31FlashLite},
 	{Name: LlamaProvider, DefaultModel: DefaultLlamaModel},
 	{Name: MiMoProvider, DefaultModel: DefaultMiMoModel},

--- a/internal/connector/providers_test.go
+++ b/internal/connector/providers_test.go
@@ -21,6 +21,7 @@ func TestSupportedProvidersIsAlphabeticalAndIncludesMiMo(t *testing.T) {
 
 func TestDefaultModelFor(t *testing.T) {
 	assert.Equal(t, string(DefaultOpenAIModel), DefaultModelFor(OpenaiProvider))
+	assert.Equal(t, string(DefaultOpenAIModel), DefaultModelFor(CodexProvider))
 	assert.Equal(t, DefaultMiMoModel, DefaultModelFor(MiMoProvider))
 	assert.Equal(t, DefaultMistralModel, DefaultModelFor(MistralProvider))
 	assert.Equal(t, string(ClaudeHaiku), DefaultModelFor(BedrockProvider))

--- a/internal/gui/settings_validation.go
+++ b/internal/gui/settings_validation.go
@@ -33,8 +33,14 @@ func providerSetupHint(provider string) string {
 			return ""
 		}
 		if os.Getenv("OPENAI_API_KEY") == "" {
-			return "OpenAI requires OPENAI_API_KEY or 'agent auth login openai'."
+			return "OpenAI requires OPENAI_API_KEY or 'agent auth login openai --api-key'."
 		}
+	case connector.CodexProvider:
+		status, err := auth.NewManager().Status(provider)
+		if err == nil && status.Configured {
+			return ""
+		}
+		return "Codex requires 'agent auth login codex'."
 	case connector.AnthropicProvider:
 		if os.Getenv("ANTHROPIC_API_KEY") == "" {
 			return "Anthropic requires ANTHROPIC_API_KEY to be set."
@@ -76,9 +82,15 @@ func providerReadinessStatus(provider string) providerReadiness {
 		}
 		status, err := auth.NewManager().Status(provider)
 		if err == nil && status.Configured {
-			return providerReadiness{Available: true, Message: "Available: stored OpenAI auth is configured."}
+			return providerReadiness{Available: true, Message: "Available: stored OpenAI API key is configured."}
 		}
-		return providerReadiness{Message: "Unavailable: OPENAI_API_KEY is not visible to the GUI process, and no stored OpenAI auth is configured."}
+		return providerReadiness{Message: "Unavailable: OPENAI_API_KEY is not visible to the GUI process, and no stored OpenAI API key is configured."}
+	case connector.CodexProvider:
+		status, err := auth.NewManager().Status(provider)
+		if err == nil && status.Configured {
+			return providerReadiness{Available: true, Message: "Available: stored Codex OAuth login is configured."}
+		}
+		return providerReadiness{Message: "Unavailable: no stored Codex OAuth login is configured."}
 	case connector.AnthropicProvider:
 		return envProviderReadiness("Anthropic", "ANTHROPIC_API_KEY")
 	case connector.GoogleProvider:
@@ -136,9 +148,9 @@ func explainRuntimeError(provider string, err error) string {
 		if hint != "" {
 			return hint
 		}
-	case strings.Contains(lower, "oauth login has expired"), strings.Contains(lower, "agent auth login openai' again"):
-		if provider == connector.OpenaiProvider {
-			return "Stored OpenAI login has expired. Run 'agent auth login openai' again or set OPENAI_API_KEY."
+	case strings.Contains(lower, "oauth login has expired"), strings.Contains(lower, "agent auth login codex' again"):
+		if provider == connector.CodexProvider {
+			return "Stored Codex login has expired. Run 'agent auth login codex' again."
 		}
 	case strings.Contains(lower, "status code: 401"), strings.Contains(lower, "status code 401"):
 		if hint != "" {

--- a/internal/gui/settings_validation_test.go
+++ b/internal/gui/settings_validation_test.go
@@ -16,6 +16,17 @@ func TestProviderSetupHintMiMo(t *testing.T) {
 	assert.Contains(t, providerSetupHint(connector.MiMoProvider), "MIMO_API_KEY")
 }
 
+func TestProviderSetupHintOpenAIUsesAPIKeyOnly(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENAI_API_KEY", "")
+	assert.Contains(t, providerSetupHint(connector.OpenaiProvider), "agent auth login openai --api-key")
+}
+
+func TestProviderSetupHintCodexUsesOAuth(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	assert.Contains(t, providerSetupHint(connector.CodexProvider), "agent auth login codex")
+}
+
 func TestProviderReadinessMiMoMissing(t *testing.T) {
 	t.Setenv("MIMO_API_KEY", "")
 
@@ -69,7 +80,7 @@ func TestFilterProviders(t *testing.T) {
 
 	// "o" matches every provider whose name contains the letter o.
 	assert.ElementsMatch(t,
-		[]string{"anthropic", "bedrock", "google", "mimo", "ollama", "openai"},
+		[]string{"anthropic", "bedrock", "codex", "google", "mimo", "ollama", "openai"},
 		filterProviders(all, "o"),
 	)
 	// Case-insensitive.


### PR DESCRIPTION
## Summary
- split API-key OpenAI into the `openai` provider and OAuth-backed ChatGPT/Codex into a new `codex` provider
- update auth resolution, login/logout/status behavior, GUI readiness hints, defaults, and docs
- migrate legacy OAuth credentials stored under `openai` to `codex` on successful Codex auth resolution

## Tests
- `go test ./internal/auth ./internal/connector ./internal/commands ./internal/config ./internal/gui`
- `task test:unit`