### PR TITLE
feat(gui): load environment for desktop app

### DIFF
--- a/cmd/agent-gui/main.go
+++ b/cmd/agent-gui/main.go
@@ -115,7 +115,11 @@ func main() {
 	}
 	defer os.Remove(instance.SocketPath)
 
-	guiApp := gui.NewApp(service, cfg, windowAppID, *devMode, displayVersion())
+	guiApp := gui.NewApp(service, cfg, gui.AppOptions{
+		AppID:   windowAppID,
+		DevMode: *devMode,
+		Version: displayVersion(),
+	})
 	server, err := platform.Listen(instance.SocketPath, func(command string) error {
 		switch command {
 		case platform.CommandShow:

--- a/cmd/agent-gui/main.go
+++ b/cmd/agent-gui/main.go
@@ -95,7 +95,7 @@ func main() {
 		if errors.Is(err, platform.ErrAlreadyRunning) {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
-			if err := platform.Send(ctx, filepath.Join(platform.RuntimeDir(guiAppID), "ipc.sock"), platform.CommandShow); err != nil {
+			if err := signalExistingGUI(ctx); err != nil {
 				logger.Error("failed to signal existing GUI instance", zap.Error(err))
 				fmt.Println("Failed to signal existing GUI instance")
 				os.Exit(1)
@@ -138,6 +138,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer server.Close()
+	guiApp.LoadInitialEnvironment()
 
 	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -151,4 +152,22 @@ func main() {
 		logger.Debug("starting visible GUI from --show")
 	}
 	guiApp.Run()
+}
+
+func signalExistingGUI(ctx context.Context) error {
+	socketPath := filepath.Join(platform.RuntimeDir(guiAppID), "ipc.sock")
+	for {
+		err := platform.Send(ctx, socketPath, platform.CommandShow)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
 }

--- a/cmd/agent-gui/main.go
+++ b/cmd/agent-gui/main.go
@@ -5,13 +5,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
-	"sync"
 	"syscall"
 	"time"
 
@@ -22,7 +20,6 @@ import (
 	"github.com/laszukdawid/terminal-agent/internal/platform"
 	u "github.com/laszukdawid/terminal-agent/internal/utils"
 	"go.uber.org/zap"
-	"golang.org/x/term"
 )
 
 var (
@@ -143,60 +140,18 @@ func main() {
 	defer server.Close()
 	guiApp.LoadInitialEnvironment()
 
-	stopTerminalQuit := watchTerminalQuit(guiApp, server)
-	defer stopTerminalQuit()
+	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-sigCtx.Done()
+		server.Close()
+		os.Exit(0)
+	}()
 
 	if *show {
 		logger.Debug("starting visible GUI from --show")
 	}
 	guiApp.Run()
-}
-
-func watchTerminalQuit(guiApp *gui.App, server *platform.IPCServer) func() {
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-	stop := make(chan struct{})
-	var quitOnce sync.Once
-	quit := func() {
-		quitOnce.Do(func() {
-			_ = server.Close()
-			guiApp.Quit()
-		})
-	}
-
-	go func() {
-		select {
-		case <-signals:
-			quit()
-		case <-stop:
-		}
-	}()
-
-	if term.IsTerminal(int(os.Stdin.Fd())) {
-		go func() {
-			buf := make([]byte, 1)
-			for {
-				_, err := os.Stdin.Read(buf)
-				if errors.Is(err, io.EOF) {
-					quit()
-					return
-				}
-				if err != nil {
-					return
-				}
-				select {
-				case <-stop:
-					return
-				default:
-				}
-			}
-		}()
-	}
-
-	return func() {
-		signal.Stop(signals)
-		close(stop)
-	}
 }
 
 func signalExistingGUI(ctx context.Context) error {

--- a/cmd/agent-gui/main.go
+++ b/cmd/agent-gui/main.go
@@ -145,7 +145,7 @@ func main() {
 	go func() {
 		<-sigCtx.Done()
 		server.Close()
-		fyne.Do(guiApp.Hide)
+		fyne.Do(guiApp.Quit)
 	}()
 
 	if *show {

--- a/cmd/agent-gui/main.go
+++ b/cmd/agent-gui/main.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
+	"sync"
 	"syscall"
 	"time"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/laszukdawid/terminal-agent/internal/platform"
 	u "github.com/laszukdawid/terminal-agent/internal/utils"
 	"go.uber.org/zap"
+	"golang.org/x/term"
 )
 
 var (
@@ -140,18 +143,60 @@ func main() {
 	defer server.Close()
 	guiApp.LoadInitialEnvironment()
 
-	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-	go func() {
-		<-sigCtx.Done()
-		server.Close()
-		fyne.Do(guiApp.Quit)
-	}()
+	stopTerminalQuit := watchTerminalQuit(guiApp, server)
+	defer stopTerminalQuit()
 
 	if *show {
 		logger.Debug("starting visible GUI from --show")
 	}
 	guiApp.Run()
+}
+
+func watchTerminalQuit(guiApp *gui.App, server *platform.IPCServer) func() {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	stop := make(chan struct{})
+	var quitOnce sync.Once
+	quit := func() {
+		quitOnce.Do(func() {
+			_ = server.Close()
+			guiApp.Quit()
+		})
+	}
+
+	go func() {
+		select {
+		case <-signals:
+			quit()
+		case <-stop:
+		}
+	}()
+
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		go func() {
+			buf := make([]byte, 1)
+			for {
+				_, err := os.Stdin.Read(buf)
+				if errors.Is(err, io.EOF) {
+					quit()
+					return
+				}
+				if err != nil {
+					return
+				}
+				select {
+				case <-stop:
+					return
+				default:
+				}
+			}
+		}()
+	}
+
+	return func() {
+		signal.Stop(signals)
+		close(stop)
+	}
 }
 
 func signalExistingGUI(ctx context.Context) error {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,8 +231,39 @@ export YZMA_LIB=$HOME/.local/share/yzma/lib
 ```
 
 For persistent CLI configuration, add this to your shell profile (`.bashrc`, `.zshrc`, etc.).
-Desktop-launched GUI processes usually do not source shell startup files, so variables set only there may not be visible to `agent-gui`.
-If the GUI reports a provider key as unavailable, export it through your desktop/session environment or start `agent-gui` from a shell that already has the variable.
+
+### GUI Environment Loading
+
+Desktop-launched GUI processes usually do not source shell startup files directly. On startup, `agent-gui` resolves supported environment variables in this order:
+
+1. Existing process environment from the launcher/session
+2. GUI env file at `~/.config/terminal-agent/.gui.env`
+3. Interactive shell import, when enabled
+4. Stored OpenAI auth, when no `OPENAI_API_KEY` is visible
+
+Use `.gui.env` when you want app-specific tokens that are separate from personal shell tokens:
+
+```sh
+OPENAI_API_KEY=your_gui_api_key_here
+GEMINI_API_KEY=your_gui_api_key_here
+TAVILY_KEY=your_gui_api_key_here
+```
+
+The GUI env file supports simple `KEY=value` lines and optional `export KEY=value` lines. It is parsed as data, not executed as a shell script. Keep it private with `chmod 600 ~/.config/terminal-agent/.gui.env`.
+
+Shell import is enabled by default and fills only missing supported variables. Configure the behavior in `~/.config/terminal-agent/config.json`:
+
+```json
+{
+  "gui": {
+    "env_file": "~/.config/terminal-agent/.gui.env",
+    "load_shell_environment": true,
+    "shell_environment_timeout": "2s"
+  }
+}
+```
+
+The Settings dialog reports where visible variables came from and includes `Reload Environment`. Manual reload updates values previously loaded from the app env file or shell import, while preserving values that came from the original process environment.
 
 ## Model Context Protocol (MCP)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,7 +263,7 @@ Shell import is enabled by default and fills only missing supported variables. C
 }
 ```
 
-The Settings dialog reports where visible variables came from and includes `Reload Environment`. Manual reload updates values previously loaded from the app env file or shell import, while preserving values that came from the original process environment.
+The Settings dialog reports whether the GUI environment was loaded. Restart `agent-gui` after changing `.gui.env` or shell startup files.
 
 ## Model Context Protocol (MCP)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,13 +251,13 @@ TAVILY_KEY=your_gui_api_key_here
 
 The GUI env file supports simple `KEY=value` lines and optional `export KEY=value` lines. It is parsed as data, not executed as a shell script. Keep it private with `chmod 600 ~/.config/terminal-agent/.gui.env`.
 
-Shell import is enabled by default and fills only missing supported variables. Configure the behavior in `~/.config/terminal-agent/config.json`:
+Shell import is disabled by default because shell startup files can be slow or interactive. Enable it only if you want `agent-gui` to fill missing supported variables from your shell environment:
 
 ```json
 {
   "gui": {
     "env_file": "~/.config/terminal-agent/.gui.env",
-    "load_shell_environment": true,
+    "load_shell_environment": false,
     "shell_environment_timeout": "2s"
   }
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ GEMINI_API_KEY=your_gui_api_key_here
 TAVILY_KEY=your_gui_api_key_here
 ```
 
-The Settings dialog reports whether provider variables such as `MIMO_API_KEY` are visible to the GUI process and includes a `Reload Environment` button for token changes while the GUI is running.
+The Settings dialog reports whether provider variables such as `MIMO_API_KEY` are visible to the GUI process. Restart `agent-gui` after changing `.gui.env` or shell startup files.
 
 If you want to use the direct local `llama` provider instead of an API-backed provider:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,8 +98,16 @@ export GEMINI_API_KEY=your_api_key_here
 # For Amazon Bedrock, configure your AWS credentials as usual
 ```
 
-If you use the popup GUI from a desktop launcher or global shortcut, remember that it may not inherit variables from shell startup files like `~/.bashrc`.
-The Settings dialog reports whether provider variables such as `MIMO_API_KEY` are visible to the GUI process.
+If you use the popup GUI from a desktop launcher or global shortcut, `agent-gui` loads GUI credentials from `~/.config/terminal-agent/.gui.env` and then imports missing supported variables from your interactive shell environment.
+Use `.gui.env` when you want app-specific tokens that are separate from personal shell tokens:
+
+```sh
+OPENAI_API_KEY=your_gui_api_key_here
+GEMINI_API_KEY=your_gui_api_key_here
+TAVILY_KEY=your_gui_api_key_here
+```
+
+The Settings dialog reports whether provider variables such as `MIMO_API_KEY` are visible to the GUI process and includes a `Reload Environment` button for token changes while the GUI is running.
 
 If you want to use the direct local `llama` provider instead of an API-backed provider:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,7 @@ export GEMINI_API_KEY=your_api_key_here
 # For Amazon Bedrock, configure your AWS credentials as usual
 ```
 
-If you use the popup GUI from a desktop launcher or global shortcut, `agent-gui` loads GUI credentials from `~/.config/terminal-agent/.gui.env` and then imports missing supported variables from your interactive shell environment.
+If you use the popup GUI from a desktop launcher or global shortcut, `agent-gui` loads GUI credentials from `~/.config/terminal-agent/.gui.env`.
 Use `.gui.env` when you want app-specific tokens that are separate from personal shell tokens:
 
 ```sh

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -21,6 +21,9 @@ type Config interface {
 	GetDefaultModelId() string
 	GetLlamaModels() map[string]string
 	GetDevice() string
+	GetGUIEnvFile() string
+	GetGUILoadShellEnvironment() bool
+	GetGUIShellEnvironmentTimeout() time.Duration
 	SetDefaultProvider(string) error
 	SetDefaultModelId(string) error
 	SetDevice(string) error
@@ -42,6 +45,7 @@ type config struct {
 	DefaultProvider string            `json:"default_provider"`
 	Providers       map[string]string `json:"providers"`
 	LlamaModels     map[string]string `json:"llama_models,omitempty"`
+	GUI             GUIConfig         `json:"gui,omitempty"`
 	Device          string            `json:"device,omitempty"`
 	McpFilePath     string            `json:"mcp_file_path"`
 	WorkingDir      string            `json:"working_dir"`
@@ -50,6 +54,12 @@ type config struct {
 	Memory          bool              `json:"memory"`
 	ProjectContext  *bool             `json:"project_context,omitempty"`
 	Permissions     Permissions       `json:"permissions,omitempty"`
+}
+
+type GUIConfig struct {
+	EnvFile                 string `json:"env_file,omitempty"`
+	LoadShellEnvironment    *bool  `json:"load_shell_environment,omitempty"`
+	ShellEnvironmentTimeout string `json:"shell_environment_timeout,omitempty"`
 }
 
 func ensurePathExists(path string) error {
@@ -74,6 +84,10 @@ func ensurePathExists(path string) error {
 
 func getDefaultWorkingDir() string {
 	return filepath.Dir(getConfigPath())
+}
+
+func getDefaultGUIEnvFile() string {
+	return filepath.Join(filepath.Dir(getConfigPath()), ".gui.env")
 }
 
 func NewDefaultConfig() *config {
@@ -183,6 +197,42 @@ func (config *config) GetDevice() string {
 		return "auto"
 	}
 	return device
+}
+
+func (config *config) GetGUIEnvFile() string {
+	if config.GUI.EnvFile == "" {
+		return getDefaultGUIEnvFile()
+	}
+	return expandHome(config.GUI.EnvFile)
+}
+
+func (config *config) GetGUILoadShellEnvironment() bool {
+	if config.GUI.LoadShellEnvironment == nil {
+		return true
+	}
+	return *config.GUI.LoadShellEnvironment
+}
+
+func (config *config) GetGUIShellEnvironmentTimeout() time.Duration {
+	if config.GUI.ShellEnvironmentTimeout == "" {
+		return 2 * time.Second
+	}
+	d, err := time.ParseDuration(config.GUI.ShellEnvironmentTimeout)
+	if err != nil || d <= 0 {
+		log.Warnw("Invalid gui.shell_environment_timeout in config, using default", "value", config.GUI.ShellEnvironmentTimeout, "error", err)
+		return 2 * time.Second
+	}
+	return d
+}
+
+func expandHome(path string) string {
+	if path == "~" {
+		return os.Getenv("HOME")
+	}
+	if len(path) > 2 && path[:2] == "~/" {
+		return filepath.Join(os.Getenv("HOME"), path[2:])
+	}
+	return path
 }
 
 func (config *config) SetDefaultModelId(modelId string) error {

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -19,6 +19,7 @@ func getConfigPath() string {
 type Config interface {
 	GetDefaultProvider() string
 	GetDefaultModelId() string
+	GetModelIdForProvider(string) string
 	GetLlamaModels() map[string]string
 	GetDevice() string
 	GetGUIEnvFile() string
@@ -170,7 +171,11 @@ func (config *config) SetDefaultProvider(provider string) error {
 }
 
 func (config *config) GetDefaultModelId() string {
-	return config.Providers[config.DefaultProvider]
+	return config.GetModelIdForProvider(config.DefaultProvider)
+}
+
+func (config *config) GetModelIdForProvider(provider string) string {
+	return config.Providers[provider]
 }
 
 func (config *config) GetLlamaModels() map[string]string {

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -213,7 +213,7 @@ func (config *config) GetGUIEnvFile() string {
 
 func (config *config) GetGUILoadShellEnvironment() bool {
 	if config.GUI.LoadShellEnvironment == nil {
-		return true
+		return false
 	}
 	return *config.GUI.LoadShellEnvironment
 }

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -158,6 +159,45 @@ func TestDeviceDefaultsToAuto(t *testing.T) {
 
 	cfg.Device = "invalid"
 	assert.Equal(t, "auto", cfg.GetDevice())
+}
+
+func TestGUIConfigDefaults(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	cfg := NewDefaultConfig()
+
+	assert.Equal(t, filepath.Join(homeDir, ".config", "terminal-agent", ".gui.env"), cfg.GetGUIEnvFile())
+	assert.True(t, cfg.GetGUILoadShellEnvironment())
+	assert.Equal(t, 2*time.Second, cfg.GetGUIShellEnvironmentTimeout())
+}
+
+func TestLoadConfigGUIOverrides(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	configDir := filepath.Join(homeDir, ".config", "terminal-agent")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	loadShell := false
+	content, err := json.Marshal(map[string]any{
+		"default_provider": "openai",
+		"providers": map[string]string{
+			"openai": "gpt-4o-mini",
+		},
+		"gui": GUIConfig{
+			EnvFile:                 "~/custom-gui.env",
+			LoadShellEnvironment:    &loadShell,
+			ShellEnvironmentTimeout: "500ms",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.json"), content, 0o600))
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(homeDir, "custom-gui.env"), cfg.GetGUIEnvFile())
+	assert.False(t, cfg.GetGUILoadShellEnvironment())
+	assert.Equal(t, 500*time.Millisecond, cfg.GetGUIShellEnvironmentTimeout())
 }
 
 func TestSetDevice(t *testing.T) {

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -150,6 +150,17 @@ func TestLoadConfig(t *testing.T) {
 	})
 }
 
+func TestGetModelIdForProvider(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.Providers["google"] = "gemini-custom"
+	cfg.Providers["anthropic"] = "claude-custom"
+	cfg.DefaultProvider = "google"
+
+	assert.Equal(t, "gemini-custom", cfg.GetDefaultModelId())
+	assert.Equal(t, "gemini-custom", cfg.GetModelIdForProvider("google"))
+	assert.Equal(t, "claude-custom", cfg.GetModelIdForProvider("anthropic"))
+}
+
 func TestDeviceDefaultsToAuto(t *testing.T) {
 	cfg := NewDefaultConfig()
 	assert.Equal(t, "auto", cfg.GetDevice())

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -179,7 +179,7 @@ func TestGUIConfigDefaults(t *testing.T) {
 	cfg := NewDefaultConfig()
 
 	assert.Equal(t, filepath.Join(homeDir, ".config", "terminal-agent", ".gui.env"), cfg.GetGUIEnvFile())
-	assert.True(t, cfg.GetGUILoadShellEnvironment())
+	assert.False(t, cfg.GetGUILoadShellEnvironment())
 	assert.Equal(t, 2*time.Second, cfg.GetGUIShellEnvironmentTimeout())
 }
 

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -239,6 +239,9 @@ func (g *App) openSettings() {
 		InitialModel:    g.cfg.GetDefaultModelId(),
 		Version:         g.version,
 		EnvResult:       g.envResult,
+		ModelForProvider: func(provider string) string {
+			return g.cfg.GetModelIdForProvider(provider)
+		},
 		OnSave: func(provider, model string) error {
 			provider = strings.TrimSpace(provider)
 			model = strings.TrimSpace(model)

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -21,12 +21,18 @@ type App struct {
 	popup         *popupWindow
 	quit          func()
 	stopIndicator chan struct{}
-	devMode       bool
 	version       string
+	envResult     EnvironmentLoadResult
 }
 
-func NewApp(service appservice.Service, cfg config.Config, appID string, devMode bool, version string) *App {
-	fyneApp := app.NewWithID(appID)
+type AppOptions struct {
+	AppID   string
+	DevMode bool
+	Version string
+}
+
+func NewApp(service appservice.Service, cfg config.Config, options AppOptions) *App {
+	fyneApp := app.NewWithID(options.AppID)
 	gui := &App{
 		fyneApp:       fyneApp,
 		service:       service,
@@ -34,13 +40,13 @@ func NewApp(service appservice.Service, cfg config.Config, appID string, devMode
 		state:         &state{},
 		quit:          fyneApp.Quit,
 		stopIndicator: make(chan struct{}),
-		devMode:       devMode,
-		version:       version,
+		version:       options.Version,
+		envResult:     LoadEnvironment(cfg, nil),
 	}
 	if icon, err := loadAppIcon(); err == nil {
 		fyneApp.SetIcon(icon)
 	}
-	gui.popup = newPopupWindow(fyneApp, devMode)
+	gui.popup = newPopupWindow(fyneApp, options.DevMode)
 	gui.wire()
 	gui.render()
 	return gui
@@ -225,22 +231,32 @@ func (g *App) render() {
 }
 
 func (g *App) openSettings() {
-	g.popup.showSettingsDialog(g.cfg.GetDefaultProvider(), g.cfg.GetDefaultModelId(), g.version, func(provider, model string) error {
-		provider = strings.TrimSpace(provider)
-		model = strings.TrimSpace(model)
-		if err := validateProviderModel(provider, model); err != nil {
-			return err
-		}
-		if err := g.cfg.SetDefaultProvider(provider); err != nil {
-			return err
-		}
-		if err := g.cfg.SetDefaultModelId(model); err != nil {
-			return err
-		}
-		g.state.status = "Settings saved."
-		g.state.errorText = ""
-		g.render()
-		return nil
+	g.popup.showSettingsDialog(settingsDialogOptions{
+		InitialProvider: g.cfg.GetDefaultProvider(),
+		InitialModel:    g.cfg.GetDefaultModelId(),
+		Version:         g.version,
+		EnvResult:       g.envResult,
+		OnReloadEnv: func() EnvironmentLoadResult {
+			g.envResult = LoadEnvironment(g.cfg, g.envResult.Sources)
+			return g.envResult
+		},
+		OnSave: func(provider, model string) error {
+			provider = strings.TrimSpace(provider)
+			model = strings.TrimSpace(model)
+			if err := validateProviderModel(provider, model); err != nil {
+				return err
+			}
+			if err := g.cfg.SetDefaultProvider(provider); err != nil {
+				return err
+			}
+			if err := g.cfg.SetDefaultModelId(model); err != nil {
+				return err
+			}
+			g.state.status = "Settings saved."
+			g.state.errorText = ""
+			g.render()
+			return nil
+		},
 	})
 }
 

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -93,6 +93,14 @@ func (g *App) Hide() {
 	g.popup.window.Hide()
 }
 
+func (g *App) Quit() {
+	if g.state.cancelFunc != nil {
+		g.state.cancelFunc()
+		g.state.clearRunning()
+	}
+	g.quit()
+}
+
 func (g *App) startIndicator() {
 	stop := make(chan struct{})
 	g.stopIndicator = stop
@@ -143,6 +151,7 @@ func (g *App) wire() {
 	g.popup.onEscape = func() {
 		g.Hide()
 	}
+	g.popup.onQuit = g.Quit
 	g.popup.onInput = func(value string) {
 		g.state.input = value
 		g.state.showRequest = g.state.question != "" && value != g.state.question
@@ -168,7 +177,7 @@ func (g *App) wire() {
 			}),
 			fyne.NewMenuItemSeparator(),
 			fyne.NewMenuItem("Quit", func() {
-				g.quit()
+				g.Quit()
 			}),
 		)
 		desk.SetSystemTrayMenu(trayMenu)

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -57,7 +57,7 @@ func (g *App) Run() {
 }
 
 func (g *App) LoadInitialEnvironment() {
-	g.envResult = LoadEnvironment(g.cfg, nil)
+	g.envResult = LoadEnvironment(g.cfg)
 }
 
 func (g *App) Show() {
@@ -239,10 +239,6 @@ func (g *App) openSettings() {
 		InitialModel:    g.cfg.GetDefaultModelId(),
 		Version:         g.version,
 		EnvResult:       g.envResult,
-		OnReloadEnv: func() EnvironmentLoadResult {
-			g.envResult = LoadEnvironment(g.cfg, g.envResult.Sources)
-			return g.envResult
-		},
 		OnSave: func(provider, model string) error {
 			provider = strings.TrimSpace(provider)
 			model = strings.TrimSpace(model)

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -41,7 +41,6 @@ func NewApp(service appservice.Service, cfg config.Config, options AppOptions) *
 		quit:          fyneApp.Quit,
 		stopIndicator: make(chan struct{}),
 		version:       options.Version,
-		envResult:     LoadEnvironment(cfg, nil),
 	}
 	if icon, err := loadAppIcon(); err == nil {
 		fyneApp.SetIcon(icon)
@@ -55,6 +54,10 @@ func NewApp(service appservice.Service, cfg config.Config, options AppOptions) *
 func (g *App) Run() {
 	g.Show()
 	g.fyneApp.Run()
+}
+
+func (g *App) LoadInitialEnvironment() {
+	g.envResult = LoadEnvironment(g.cfg, nil)
 }
 
 func (g *App) Show() {

--- a/internal/gui/environment.go
+++ b/internal/gui/environment.go
@@ -68,20 +68,19 @@ func (r EnvironmentLoadResult) SourceFor(key string) string {
 	return r.Sources[key]
 }
 
-func LoadEnvironment(cfg environmentConfig, previousSources map[string]string) EnvironmentLoadResult {
+func LoadEnvironment(cfg environmentConfig) EnvironmentLoadResult {
 	result := EnvironmentLoadResult{
 		EnvFilePath:  cfg.GetGUIEnvFile(),
 		ShellEnabled: cfg.GetGUILoadShellEnvironment(),
 		Shell:        os.Getenv("SHELL"),
-		Sources:      processEnvironmentSources(previousSources),
+		Sources:      processEnvironmentSources(),
 	}
 
-	importedThisRun := map[string]string{}
 	fileEnv, loaded, warning, err := readEnvFile(result.EnvFilePath)
 	result.EnvFileLoaded = loaded
 	result.EnvFileWarning = warning
 	result.EnvFileError = err
-	mergeEnvironment(fileEnv, envSourceFile, previousSources, result.Sources, importedThisRun)
+	mergeEnvironment(fileEnv, envSourceFile, result.Sources)
 
 	if result.ShellEnabled {
 		start := time.Now()
@@ -90,45 +89,34 @@ func LoadEnvironment(cfg environmentConfig, previousSources map[string]string) E
 		result.ShellError = err
 		if err == nil {
 			result.ShellLoaded = true
-			mergeEnvironment(shellEnv, envSourceShell, previousSources, result.Sources, importedThisRun)
+			mergeEnvironment(shellEnv, envSourceShell, result.Sources)
 		}
 	}
 
 	return result
 }
 
-func processEnvironmentSources(previousSources map[string]string) map[string]string {
+func processEnvironmentSources() map[string]string {
 	sources := map[string]string{}
 	for key := range guiEnvironmentAllowlist {
 		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
-			if previousSources[key] == envSourceFile || previousSources[key] == envSourceShell {
-				sources[key] = previousSources[key]
-			} else {
-				sources[key] = envSourceProcess
-			}
+			sources[key] = envSourceProcess
 		}
 	}
 	return sources
 }
 
-func mergeEnvironment(values map[string]string, source string, previousSources map[string]string, sources map[string]string, importedThisRun map[string]string) {
+func mergeEnvironment(values map[string]string, source string, sources map[string]string) {
 	for key, rawValue := range values {
 		value := strings.TrimSpace(rawValue)
 		if value == "" || !isAllowedGUIEnv(key) {
 			continue
 		}
-		current := strings.TrimSpace(os.Getenv(key))
-		previous := previousSources[key]
-		canOverwrite := previous == envSourceFile || previous == envSourceShell
-		if source == envSourceShell && importedThisRun[key] == envSourceFile {
-			canOverwrite = false
-		}
-		if current != "" && !canOverwrite {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
 			continue
 		}
 		if err := os.Setenv(key, value); err == nil {
 			sources[key] = source
-			importedThisRun[key] = source
 		}
 	}
 }

--- a/internal/gui/environment.go
+++ b/internal/gui/environment.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -224,16 +223,4 @@ func parseNullSeparatedEnv(output []byte) map[string]string {
 		values[key] = value
 	}
 	return values
-}
-
-func envFileDisplayPath(path string) string {
-	home := os.Getenv("HOME")
-	if home == "" {
-		return path
-	}
-	rel, err := filepath.Rel(home, path)
-	if err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
-		return filepath.Join("~", rel)
-	}
-	return path
 }

--- a/internal/gui/environment.go
+++ b/internal/gui/environment.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -200,6 +201,8 @@ func loadShellEnvironment(timeout time.Duration) (map[string]string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, shell, "-ic", "env -0")
+	cmd.Stdin = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	output, err := cmd.Output()
 	if ctx.Err() != nil {
 		return map[string]string{}, ctx.Err()

--- a/internal/gui/environment.go
+++ b/internal/gui/environment.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -237,20 +236,6 @@ func parseNullSeparatedEnv(output []byte) map[string]string {
 		values[key] = value
 	}
 	return values
-}
-
-func visibleEnvKeysBySource(sources map[string]string) map[string][]string {
-	bySource := map[string][]string{}
-	for key, source := range sources {
-		if !isAllowedGUIEnv(key) || strings.TrimSpace(os.Getenv(key)) == "" {
-			continue
-		}
-		bySource[source] = append(bySource[source], key)
-	}
-	for source := range bySource {
-		sort.Strings(bySource[source])
-	}
-	return bySource
 }
 
 func envFileDisplayPath(path string) string {

--- a/internal/gui/environment.go
+++ b/internal/gui/environment.go
@@ -1,0 +1,266 @@
+package gui
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	envSourceProcess = "process env"
+	envSourceFile    = "app env file"
+	envSourceShell   = "shell import"
+)
+
+var guiEnvironmentAllowlist = map[string]struct{}{
+	"ANTHROPIC_API_KEY":     {},
+	"AWS_ACCESS_KEY_ID":     {},
+	"AWS_DEFAULT_REGION":    {},
+	"AWS_PROFILE":           {},
+	"AWS_REGION":            {},
+	"AWS_SECRET_ACCESS_KEY": {},
+	"AWS_SESSION_TOKEN":     {},
+	"GEMINI_API_KEY":        {},
+	"MIMO_API_KEY":          {},
+	"MIMO_BASE_URL":         {},
+	"MISTRAL_API_KEY":       {},
+	"MISTRAL_BASE_URL":      {},
+	"OLLAMA_HOST":           {},
+	"OPENAI_API_KEY":        {},
+	"OPENAI_BASE_URL":       {},
+	"PATH":                  {},
+	"TAVILY_KEY":            {},
+	"YZMA_LIB":              {},
+}
+
+type EnvironmentLoadResult struct {
+	EnvFilePath    string
+	EnvFileLoaded  bool
+	EnvFileWarning error
+	EnvFileError   error
+
+	ShellEnabled  bool
+	ShellLoaded   bool
+	Shell         string
+	ShellDuration time.Duration
+	ShellError    error
+
+	Sources map[string]string
+}
+
+type environmentConfig interface {
+	GetGUIEnvFile() string
+	GetGUILoadShellEnvironment() bool
+	GetGUIShellEnvironmentTimeout() time.Duration
+}
+
+func (r EnvironmentLoadResult) SourceFor(key string) string {
+	if r.Sources == nil {
+		return ""
+	}
+	return r.Sources[key]
+}
+
+func LoadEnvironment(cfg environmentConfig, previousSources map[string]string) EnvironmentLoadResult {
+	result := EnvironmentLoadResult{
+		EnvFilePath:  cfg.GetGUIEnvFile(),
+		ShellEnabled: cfg.GetGUILoadShellEnvironment(),
+		Shell:        os.Getenv("SHELL"),
+		Sources:      processEnvironmentSources(previousSources),
+	}
+
+	importedThisRun := map[string]string{}
+	fileEnv, loaded, warning, err := readEnvFile(result.EnvFilePath)
+	result.EnvFileLoaded = loaded
+	result.EnvFileWarning = warning
+	result.EnvFileError = err
+	mergeEnvironment(fileEnv, envSourceFile, previousSources, result.Sources, importedThisRun)
+
+	if result.ShellEnabled {
+		start := time.Now()
+		shellEnv, err := loadShellEnvironment(cfg.GetGUIShellEnvironmentTimeout())
+		result.ShellDuration = time.Since(start)
+		result.ShellError = err
+		if err == nil {
+			result.ShellLoaded = true
+			mergeEnvironment(shellEnv, envSourceShell, previousSources, result.Sources, importedThisRun)
+		}
+	}
+
+	return result
+}
+
+func processEnvironmentSources(previousSources map[string]string) map[string]string {
+	sources := map[string]string{}
+	for key := range guiEnvironmentAllowlist {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			if previousSources[key] == envSourceFile || previousSources[key] == envSourceShell {
+				sources[key] = previousSources[key]
+			} else {
+				sources[key] = envSourceProcess
+			}
+		}
+	}
+	return sources
+}
+
+func mergeEnvironment(values map[string]string, source string, previousSources map[string]string, sources map[string]string, importedThisRun map[string]string) {
+	for key, rawValue := range values {
+		value := strings.TrimSpace(rawValue)
+		if value == "" || !isAllowedGUIEnv(key) {
+			continue
+		}
+		current := strings.TrimSpace(os.Getenv(key))
+		previous := previousSources[key]
+		canOverwrite := previous == envSourceFile || previous == envSourceShell
+		if source == envSourceShell && importedThisRun[key] == envSourceFile {
+			canOverwrite = false
+		}
+		if current != "" && !canOverwrite {
+			continue
+		}
+		if err := os.Setenv(key, value); err == nil {
+			sources[key] = source
+			importedThisRun[key] = source
+		}
+	}
+}
+
+func isAllowedGUIEnv(key string) bool {
+	_, ok := guiEnvironmentAllowlist[key]
+	return ok
+}
+
+func readEnvFile(path string) (map[string]string, bool, error, error) {
+	if strings.TrimSpace(path) == "" {
+		return map[string]string{}, false, nil, nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]string{}, false, nil, nil
+		}
+		return map[string]string{}, false, nil, err
+	}
+	return parseDotenv(content), true, checkEnvFilePermissions(path), nil
+}
+
+func checkEnvFilePermissions(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("%s is readable by group or others; consider chmod 600", path)
+	}
+	return nil
+}
+
+func parseDotenv(content []byte) map[string]string {
+	values := map[string]string{}
+	for _, rawLine := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if !isAllowedGUIEnv(key) {
+			continue
+		}
+		values[key] = unquoteEnvValue(strings.TrimSpace(value))
+	}
+	return values
+}
+
+func unquoteEnvValue(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+	quote := value[0]
+	if (quote != '\'' && quote != '"') || value[len(value)-1] != quote {
+		return value
+	}
+	if quote == '\'' {
+		return value[1 : len(value)-1]
+	}
+	unquoted, err := strconv.Unquote(value)
+	if err != nil {
+		return value[1 : len(value)-1]
+	}
+	return unquoted
+}
+
+func loadShellEnvironment(timeout time.Duration) (map[string]string, error) {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, shell, "-ic", "env -0")
+	output, err := cmd.Output()
+	if ctx.Err() != nil {
+		return map[string]string{}, ctx.Err()
+	}
+	if err != nil {
+		return map[string]string{}, err
+	}
+	return parseNullSeparatedEnv(output), nil
+}
+
+func parseNullSeparatedEnv(output []byte) map[string]string {
+	values := map[string]string{}
+	for _, part := range bytes.Split(output, []byte{0}) {
+		if len(part) == 0 {
+			continue
+		}
+		key, value, ok := strings.Cut(string(part), "=")
+		if !ok || !isAllowedGUIEnv(key) {
+			continue
+		}
+		values[key] = value
+	}
+	return values
+}
+
+func visibleEnvKeysBySource(sources map[string]string) map[string][]string {
+	bySource := map[string][]string{}
+	for key, source := range sources {
+		if !isAllowedGUIEnv(key) || strings.TrimSpace(os.Getenv(key)) == "" {
+			continue
+		}
+		bySource[source] = append(bySource[source], key)
+	}
+	for source := range bySource {
+		sort.Strings(bySource[source])
+	}
+	return bySource
+}
+
+func envFileDisplayPath(path string) string {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return path
+	}
+	rel, err := filepath.Rel(home, path)
+	if err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+		return filepath.Join("~", rel)
+	}
+	return path
+}

--- a/internal/gui/environment_test.go
+++ b/internal/gui/environment_test.go
@@ -54,7 +54,7 @@ func TestLoadEnvironmentUsesEnvFileBeforeShell(t *testing.T) {
 	shell := writeShellEnvScript(t, "OPENAI_API_KEY=shell-openai", "GEMINI_API_KEY=shell-gemini", "DISPLAY=bad")
 	t.Setenv("SHELL", shell)
 
-	result := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true}, nil)
+	result := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true})
 
 	if result.EnvFileError != nil {
 		t.Fatalf("EnvFileError = %v", result.EnvFileError)
@@ -84,7 +84,7 @@ func TestLoadEnvironmentDoesNotOverwriteProcessEnv(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "process-openai")
 	envFile := writeTestEnvFile(t, "OPENAI_API_KEY=file-openai\n")
 
-	result := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: false}, nil)
+	result := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: false})
 
 	if got := os.Getenv("OPENAI_API_KEY"); got != "process-openai" {
 		t.Fatalf("OPENAI_API_KEY = %q, want process-openai", got)
@@ -104,7 +104,7 @@ func TestLoadEnvironmentReportsEnvFilePermissionWarningWithoutBlockingLoad(t *te
 		t.Fatal(err)
 	}
 
-	result := LoadEnvironment(envTestConfig{envFile: path, loadShell: false}, nil)
+	result := LoadEnvironment(envTestConfig{envFile: path, loadShell: false})
 
 	if !result.EnvFileLoaded {
 		t.Fatal("env file should be loaded")
@@ -117,63 +117,6 @@ func TestLoadEnvironmentReportsEnvFilePermissionWarningWithoutBlockingLoad(t *te
 	}
 	if got := os.Getenv("OPENAI_API_KEY"); got != "file-openai" {
 		t.Fatalf("OPENAI_API_KEY = %q, want file-openai", got)
-	}
-}
-
-func TestLoadEnvironmentReloadOverwritesImportedValues(t *testing.T) {
-	clearTestEnv(t, "OPENAI_API_KEY", "GEMINI_API_KEY")
-	dir := t.TempDir()
-	envFile := filepath.Join(dir, "gui.env")
-	if err := os.WriteFile(envFile, []byte("OPENAI_API_KEY=file-one\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	shell := writeShellEnvScript(t, "GEMINI_API_KEY=shell-one")
-	t.Setenv("SHELL", shell)
-
-	first := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true}, nil)
-	if err := os.WriteFile(envFile, []byte("OPENAI_API_KEY=file-two\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	shell = writeShellEnvScript(t, "GEMINI_API_KEY=shell-two", "OPENAI_API_KEY=shell-two")
-	t.Setenv("SHELL", shell)
-
-	second := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true}, first.Sources)
-
-	if got := os.Getenv("OPENAI_API_KEY"); got != "file-two" {
-		t.Fatalf("OPENAI_API_KEY = %q, want file-two", got)
-	}
-	if got := os.Getenv("GEMINI_API_KEY"); got != "shell-two" {
-		t.Fatalf("GEMINI_API_KEY = %q, want shell-two", got)
-	}
-	if second.SourceFor("OPENAI_API_KEY") != envSourceFile {
-		t.Fatalf("OPENAI_API_KEY source = %q, want %q", second.SourceFor("OPENAI_API_KEY"), envSourceFile)
-	}
-}
-
-func TestLoadEnvironmentReloadLetsShellFillRemovedEnvFileValue(t *testing.T) {
-	clearTestEnv(t, "OPENAI_API_KEY")
-	dir := t.TempDir()
-	envFile := filepath.Join(dir, "gui.env")
-	if err := os.WriteFile(envFile, []byte("OPENAI_API_KEY=file-one\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	shell := writeShellEnvScript(t, "OPENAI_API_KEY=shell-one")
-	t.Setenv("SHELL", shell)
-
-	first := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true}, nil)
-	if err := os.WriteFile(envFile, []byte(""), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	shell = writeShellEnvScript(t, "OPENAI_API_KEY=shell-two")
-	t.Setenv("SHELL", shell)
-
-	second := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true}, first.Sources)
-
-	if got := os.Getenv("OPENAI_API_KEY"); got != "shell-two" {
-		t.Fatalf("OPENAI_API_KEY = %q, want shell-two", got)
-	}
-	if second.SourceFor("OPENAI_API_KEY") != envSourceShell {
-		t.Fatalf("OPENAI_API_KEY source = %q, want %q", second.SourceFor("OPENAI_API_KEY"), envSourceShell)
 	}
 }
 

--- a/internal/gui/environment_test.go
+++ b/internal/gui/environment_test.go
@@ -1,0 +1,208 @@
+package gui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type envTestConfig struct {
+	envFile      string
+	loadShell    bool
+	shellTimeout time.Duration
+}
+
+func (c envTestConfig) GetGUIEnvFile() string {
+	return c.envFile
+}
+func (c envTestConfig) GetGUILoadShellEnvironment() bool { return c.loadShell }
+func (c envTestConfig) GetGUIShellEnvironmentTimeout() time.Duration {
+	if c.shellTimeout == 0 {
+		return time.Second
+	}
+	return c.shellTimeout
+}
+
+func TestParseDotenv(t *testing.T) {
+	values := parseDotenv([]byte(`
+# comment
+OPENAI_API_KEY=plain
+export GEMINI_API_KEY="quoted value"
+MISTRAL_API_KEY='single quoted'
+DISPLAY=ignored
+MALFORMED
+`))
+
+	if values["OPENAI_API_KEY"] != "plain" {
+		t.Fatalf("OPENAI_API_KEY = %q, want plain", values["OPENAI_API_KEY"])
+	}
+	if values["GEMINI_API_KEY"] != "quoted value" {
+		t.Fatalf("GEMINI_API_KEY = %q, want quoted value", values["GEMINI_API_KEY"])
+	}
+	if values["MISTRAL_API_KEY"] != "single quoted" {
+		t.Fatalf("MISTRAL_API_KEY = %q, want single quoted", values["MISTRAL_API_KEY"])
+	}
+	if _, ok := values["DISPLAY"]; ok {
+		t.Fatal("DISPLAY should not be parsed")
+	}
+}
+
+func TestLoadEnvironmentUsesEnvFileBeforeShell(t *testing.T) {
+	clearTestEnv(t, "OPENAI_API_KEY", "GEMINI_API_KEY", "DISPLAY")
+	envFile := writeTestEnvFile(t, "OPENAI_API_KEY=file-openai\n")
+	shell := writeShellEnvScript(t, "OPENAI_API_KEY=shell-openai", "GEMINI_API_KEY=shell-gemini", "DISPLAY=bad")
+	t.Setenv("SHELL", shell)
+
+	result := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true}, nil)
+
+	if result.EnvFileError != nil {
+		t.Fatalf("EnvFileError = %v", result.EnvFileError)
+	}
+	if !result.EnvFileLoaded || !result.ShellLoaded {
+		t.Fatalf("loaded file=%v shell=%v", result.EnvFileLoaded, result.ShellLoaded)
+	}
+	if got := os.Getenv("OPENAI_API_KEY"); got != "file-openai" {
+		t.Fatalf("OPENAI_API_KEY = %q, want file-openai", got)
+	}
+	if got := os.Getenv("GEMINI_API_KEY"); got != "shell-gemini" {
+		t.Fatalf("GEMINI_API_KEY = %q, want shell-gemini", got)
+	}
+	if got := os.Getenv("DISPLAY"); got != "" {
+		t.Fatalf("DISPLAY = %q, want empty", got)
+	}
+	if result.SourceFor("OPENAI_API_KEY") != envSourceFile {
+		t.Fatalf("OPENAI_API_KEY source = %q, want %q", result.SourceFor("OPENAI_API_KEY"), envSourceFile)
+	}
+	if result.SourceFor("GEMINI_API_KEY") != envSourceShell {
+		t.Fatalf("GEMINI_API_KEY source = %q, want %q", result.SourceFor("GEMINI_API_KEY"), envSourceShell)
+	}
+}
+
+func TestLoadEnvironmentDoesNotOverwriteProcessEnv(t *testing.T) {
+	clearTestEnv(t, "OPENAI_API_KEY")
+	t.Setenv("OPENAI_API_KEY", "process-openai")
+	envFile := writeTestEnvFile(t, "OPENAI_API_KEY=file-openai\n")
+
+	result := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: false}, nil)
+
+	if got := os.Getenv("OPENAI_API_KEY"); got != "process-openai" {
+		t.Fatalf("OPENAI_API_KEY = %q, want process-openai", got)
+	}
+	if result.SourceFor("OPENAI_API_KEY") != envSourceProcess {
+		t.Fatalf("source = %q, want %q", result.SourceFor("OPENAI_API_KEY"), envSourceProcess)
+	}
+}
+
+func TestLoadEnvironmentReportsEnvFilePermissionWarningWithoutBlockingLoad(t *testing.T) {
+	clearTestEnv(t, "OPENAI_API_KEY")
+	path := filepath.Join(t.TempDir(), "gui.env")
+	if err := os.WriteFile(path, []byte("OPENAI_API_KEY=file-openai\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := LoadEnvironment(envTestConfig{envFile: path, loadShell: false}, nil)
+
+	if !result.EnvFileLoaded {
+		t.Fatal("env file should be loaded")
+	}
+	if result.EnvFileError != nil {
+		t.Fatalf("EnvFileError = %v, want nil", result.EnvFileError)
+	}
+	if result.EnvFileWarning == nil {
+		t.Fatal("EnvFileWarning should be set")
+	}
+	if got := os.Getenv("OPENAI_API_KEY"); got != "file-openai" {
+		t.Fatalf("OPENAI_API_KEY = %q, want file-openai", got)
+	}
+}
+
+func TestLoadEnvironmentReloadOverwritesImportedValues(t *testing.T) {
+	clearTestEnv(t, "OPENAI_API_KEY", "GEMINI_API_KEY")
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "gui.env")
+	if err := os.WriteFile(envFile, []byte("OPENAI_API_KEY=file-one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	shell := writeShellEnvScript(t, "GEMINI_API_KEY=shell-one")
+	t.Setenv("SHELL", shell)
+
+	first := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true}, nil)
+	if err := os.WriteFile(envFile, []byte("OPENAI_API_KEY=file-two\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	shell = writeShellEnvScript(t, "GEMINI_API_KEY=shell-two", "OPENAI_API_KEY=shell-two")
+	t.Setenv("SHELL", shell)
+
+	second := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true}, first.Sources)
+
+	if got := os.Getenv("OPENAI_API_KEY"); got != "file-two" {
+		t.Fatalf("OPENAI_API_KEY = %q, want file-two", got)
+	}
+	if got := os.Getenv("GEMINI_API_KEY"); got != "shell-two" {
+		t.Fatalf("GEMINI_API_KEY = %q, want shell-two", got)
+	}
+	if second.SourceFor("OPENAI_API_KEY") != envSourceFile {
+		t.Fatalf("OPENAI_API_KEY source = %q, want %q", second.SourceFor("OPENAI_API_KEY"), envSourceFile)
+	}
+}
+
+func TestLoadEnvironmentReloadLetsShellFillRemovedEnvFileValue(t *testing.T) {
+	clearTestEnv(t, "OPENAI_API_KEY")
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "gui.env")
+	if err := os.WriteFile(envFile, []byte("OPENAI_API_KEY=file-one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	shell := writeShellEnvScript(t, "OPENAI_API_KEY=shell-one")
+	t.Setenv("SHELL", shell)
+
+	first := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true}, nil)
+	if err := os.WriteFile(envFile, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	shell = writeShellEnvScript(t, "OPENAI_API_KEY=shell-two")
+	t.Setenv("SHELL", shell)
+
+	second := LoadEnvironment(envTestConfig{envFile: envFile, loadShell: true}, first.Sources)
+
+	if got := os.Getenv("OPENAI_API_KEY"); got != "shell-two" {
+		t.Fatalf("OPENAI_API_KEY = %q, want shell-two", got)
+	}
+	if second.SourceFor("OPENAI_API_KEY") != envSourceShell {
+		t.Fatalf("OPENAI_API_KEY source = %q, want %q", second.SourceFor("OPENAI_API_KEY"), envSourceShell)
+	}
+}
+
+func clearTestEnv(t *testing.T, keys ...string) {
+	t.Helper()
+	for _, key := range keys {
+		t.Setenv(key, "")
+	}
+}
+
+func writeTestEnvFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gui.env")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeShellEnvScript(t *testing.T, entries ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "shell")
+	content := "#!/bin/sh\nprintf '"
+	for _, entry := range entries {
+		content += entry + "\\0"
+	}
+	content += "'\n"
+	if err := os.WriteFile(path, []byte(content), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -564,7 +564,7 @@ func environmentSummaryText(result EnvironmentLoadResult) string {
 		lines = append(lines, "App env file warning: "+result.EnvFileWarning.Error())
 	}
 	if result.ShellError != nil {
-		lines = append(lines, "Shell import: failed: "+result.ShellError.Error())
+		lines = append(lines, "Shell import failed: "+result.ShellError.Error())
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -17,10 +17,10 @@ import (
 )
 
 const (
-	defaultWindowWidth    float32 = 720
-	defaultWindowHeight   float32 = 280
-	minWindowHeight       float32 = 240
-	maxWindowHeight       float32 = 760
+	defaultWindowWidth   float32 = 720
+	defaultWindowHeight  float32 = 280
+	minWindowHeight      float32 = 240
+	maxWindowHeight      float32 = 760
 	maxInputRows                 = 3
 	compactOutputHeight  float32 = 110
 	statusMinWidth       float32 = 130
@@ -78,6 +78,15 @@ type providerStatusIcon struct {
 	icon    *canvas.Text
 	message string
 	popup   *widget.PopUp
+}
+
+type settingsDialogOptions struct {
+	InitialProvider string
+	InitialModel    string
+	Version         string
+	EnvResult       EnvironmentLoadResult
+	OnReloadEnv     func() EnvironmentLoadResult
+	OnSave          func(provider, model string) error
 }
 
 func newProviderStatusIcon(c fyne.Canvas) *providerStatusIcon {
@@ -441,9 +450,10 @@ func (p *popupWindow) showTestDialog(tests []devTest) {
 	dlg.Show()
 }
 
-func (p *popupWindow) showSettingsDialog(initialProvider, initialModel, version string, onSave func(provider, model string) error) {
+func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
+	currentEnvResult := options.EnvResult
 	modelEntry := widget.NewEntry()
-	modelEntry.SetText(initialModel)
+	modelEntry.SetText(options.InitialModel)
 	errorLabel := widget.NewLabel("")
 	errorLabel.Wrapping = fyne.TextWrapWord
 	errorLabel.Importance = widget.DangerImportance
@@ -464,7 +474,7 @@ func (p *popupWindow) showSettingsDialog(initialProvider, initialModel, version 
 
 	updateHints := func(provider string) {
 		provider = strings.TrimSpace(provider)
-		providerStatus.setStatus(providerReadinessStatus(provider))
+		providerStatus.setStatus(providerReadinessStatusWithEnvironment(provider, currentEnvResult))
 		if def := connector.DefaultModelFor(provider); def != "" {
 			modelHint.SetText("Default model: " + def)
 		} else {
@@ -472,7 +482,7 @@ func (p *popupWindow) showSettingsDialog(initialProvider, initialModel, version 
 		}
 	}
 
-	providerInput := newProviderEntry(initialProvider, updateHints)
+	providerInput := newProviderEntry(options.InitialProvider, updateHints)
 
 	providerLabel := widget.NewLabelWithStyle("Provider", fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
 	providerLabelBox := container.NewHBox(providerLabel, providerStatus)
@@ -486,6 +496,21 @@ func (p *popupWindow) showSettingsDialog(initialProvider, initialModel, version 
 		modelLabel, modelEntry,
 		widget.NewLabel(""), modelHint,
 	)
+	environmentLabel := widget.NewLabel(environmentSummaryText(currentEnvResult))
+	environmentLabel.Wrapping = fyne.TextWrapWord
+	reloadEnvButton := widget.NewButton("Reload Environment", func() {
+		if options.OnReloadEnv == nil {
+			return
+		}
+		currentEnvResult = options.OnReloadEnv()
+		environmentLabel.SetText(environmentSummaryText(currentEnvResult))
+		updateHints(providerInput.Text)
+	})
+	environmentBox := container.NewVBox(
+		widget.NewLabelWithStyle("Environment", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		environmentLabel,
+		container.NewHBox(reloadEnvButton, layout.NewSpacer()),
+	)
 	var dlg dialog.Dialog
 	saveButton := widget.NewButton("Save", func() {
 		provider := strings.TrimSpace(providerInput.Text)
@@ -498,7 +523,11 @@ func (p *popupWindow) showSettingsDialog(initialProvider, initialModel, version 
 			errorLabel.SetText("Model cannot be empty.")
 			return
 		}
-		if err := onSave(provider, model); err != nil {
+		if options.OnSave == nil {
+			errorLabel.SetText("Settings cannot be saved.")
+			return
+		}
+		if err := options.OnSave(provider, model); err != nil {
 			errorLabel.SetText(err.Error())
 			return
 		}
@@ -508,14 +537,50 @@ func (p *popupWindow) showSettingsDialog(initialProvider, initialModel, version 
 	cancelButton := widget.NewButton("Cancel", func() {
 		dlg.Hide()
 	})
-	versionLabel := widget.NewLabelWithStyle(version, fyne.TextAlignLeading, fyne.TextStyle{Italic: true})
+	versionLabel := widget.NewLabelWithStyle(options.Version, fyne.TextAlignLeading, fyne.TextStyle{Italic: true})
 	footer := container.NewHBox(versionLabel, layout.NewSpacer(), cancelButton, saveButton)
-	content := container.NewVBox(form, errorLabel, footer)
-	updateHints(initialProvider)
+	content := container.NewVBox(form, environmentBox, errorLabel, footer)
+	updateHints(options.InitialProvider)
 
 	dlg = dialog.NewCustomWithoutButtons("Settings", content, p.window)
 	dlg.Resize(fyne.NewSize(520, 0))
 	dlg.Show()
+}
+
+func environmentSummaryText(result EnvironmentLoadResult) string {
+	lines := []string{}
+	fileStatus := "missing"
+	if result.EnvFileLoaded {
+		fileStatus = "loaded"
+	}
+	if result.EnvFileError != nil {
+		fileStatus = "error: " + result.EnvFileError.Error()
+	}
+	lines = append(lines, "App env file: "+fileStatus+" ("+envFileDisplayPath(result.EnvFilePath)+")")
+	if result.EnvFileWarning != nil {
+		lines = append(lines, "App env file warning: "+result.EnvFileWarning.Error())
+	}
+
+	switch {
+	case !result.ShellEnabled:
+		lines = append(lines, "Shell import: disabled")
+	case result.ShellLoaded:
+		lines = append(lines, "Shell import: loaded from "+result.Shell+" in "+result.ShellDuration.Truncate(10_000_000).String())
+	case result.ShellError != nil:
+		lines = append(lines, "Shell import: failed: "+result.ShellError.Error())
+	default:
+		lines = append(lines, "Shell import: not loaded")
+	}
+
+	visible := visibleEnvKeysBySource(result.Sources)
+	for _, source := range []string{envSourceProcess, envSourceFile, envSourceShell} {
+		keys := visible[source]
+		if len(keys) == 0 {
+			continue
+		}
+		lines = append(lines, source+": "+strings.Join(keys, ", "))
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (p *popupWindow) resizeInput(value string) {

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -495,12 +495,7 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 		modelLabel, modelEntry,
 		widget.NewLabel(""), modelHint,
 	)
-	environmentLabel := widget.NewLabel(environmentSummaryText(currentEnvResult))
-	environmentLabel.Wrapping = fyne.TextWrapWord
-	environmentBox := container.NewVBox(
-		widget.NewLabelWithStyle("Environment", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
-		environmentLabel,
-	)
+	environmentSummary := environmentSummaryText(currentEnvResult)
 	var dlg dialog.Dialog
 	saveButton := widget.NewButton("Save", func() {
 		provider := strings.TrimSpace(providerInput.Text)
@@ -529,7 +524,17 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 	})
 	versionLabel := widget.NewLabelWithStyle(options.Version, fyne.TextAlignLeading, fyne.TextStyle{Italic: true})
 	footer := container.NewHBox(versionLabel, layout.NewSpacer(), cancelButton, saveButton)
-	content := container.NewVBox(form, environmentBox, errorLabel, footer)
+	contentObjects := []fyne.CanvasObject{form}
+	if environmentSummary != "" {
+		environmentLabel := widget.NewLabel(environmentSummary)
+		environmentLabel.Wrapping = fyne.TextWrapWord
+		contentObjects = append(contentObjects,
+			widget.NewLabelWithStyle("Environment", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+			environmentLabel,
+		)
+	}
+	contentObjects = append(contentObjects, errorLabel, footer)
+	content := container.NewVBox(contentObjects...)
 	updateHints(options.InitialProvider)
 
 	dlg = dialog.NewCustomWithoutButtons("Settings", content, p.window)
@@ -539,27 +544,14 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 
 func environmentSummaryText(result EnvironmentLoadResult) string {
 	lines := []string{}
-	fileStatus := "missing"
-	if result.EnvFileLoaded {
-		fileStatus = "loaded"
-	}
 	if result.EnvFileError != nil {
-		fileStatus = "error: " + result.EnvFileError.Error()
+		lines = append(lines, "App env file: "+result.EnvFileError.Error())
 	}
-	lines = append(lines, "App env file: "+fileStatus+" ("+envFileDisplayPath(result.EnvFilePath)+")")
 	if result.EnvFileWarning != nil {
 		lines = append(lines, "App env file warning: "+result.EnvFileWarning.Error())
 	}
-
-	switch {
-	case !result.ShellEnabled:
-		lines = append(lines, "Shell import: disabled")
-	case result.ShellLoaded:
-		lines = append(lines, "Shell import: loaded")
-	case result.ShellError != nil:
+	if result.ShellError != nil {
 		lines = append(lines, "Shell import: failed: "+result.ShellError.Error())
-	default:
-		lines = append(lines, "Shell import: not loaded")
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"image/color"
+	"os"
 	"strings"
 
 	"fyne.io/fyne/v2"
@@ -471,10 +472,14 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 	}
 	modelHint := newHint()
 	providerStatus := newProviderStatusIcon(p.window.Canvas())
+	var environmentLabel *widget.Label
 
 	updateHints := func(provider string) {
 		provider = strings.TrimSpace(provider)
 		providerStatus.setStatus(providerReadinessStatusWithEnvironment(provider, currentEnvResult))
+		if environmentLabel != nil {
+			environmentLabel.SetText(environmentSummaryText(currentEnvResult, provider))
+		}
 		if def := connector.DefaultModelFor(provider); def != "" {
 			modelHint.SetText("Default model: " + def)
 		} else {
@@ -496,14 +501,13 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 		modelLabel, modelEntry,
 		widget.NewLabel(""), modelHint,
 	)
-	environmentLabel := widget.NewLabel(environmentSummaryText(currentEnvResult))
+	environmentLabel = widget.NewLabel(environmentSummaryText(currentEnvResult, options.InitialProvider))
 	environmentLabel.Wrapping = fyne.TextWrapWord
-	reloadEnvButton := widget.NewButton("Reload Environment", func() {
+	reloadEnvButton := widget.NewButton("Reload", func() {
 		if options.OnReloadEnv == nil {
 			return
 		}
 		currentEnvResult = options.OnReloadEnv()
-		environmentLabel.SetText(environmentSummaryText(currentEnvResult))
 		updateHints(providerInput.Text)
 	})
 	environmentBox := container.NewVBox(
@@ -547,7 +551,7 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 	dlg.Show()
 }
 
-func environmentSummaryText(result EnvironmentLoadResult) string {
+func environmentSummaryText(result EnvironmentLoadResult, provider string) string {
 	lines := []string{}
 	fileStatus := "missing"
 	if result.EnvFileLoaded {
@@ -565,22 +569,48 @@ func environmentSummaryText(result EnvironmentLoadResult) string {
 	case !result.ShellEnabled:
 		lines = append(lines, "Shell import: disabled")
 	case result.ShellLoaded:
-		lines = append(lines, "Shell import: loaded from "+result.Shell+" in "+result.ShellDuration.Truncate(10_000_000).String())
+		lines = append(lines, "Shell import: loaded ("+result.Shell+", "+result.ShellDuration.Truncate(10_000_000).String()+")")
 	case result.ShellError != nil:
 		lines = append(lines, "Shell import: failed: "+result.ShellError.Error())
 	default:
 		lines = append(lines, "Shell import: not loaded")
 	}
 
-	visible := visibleEnvKeysBySource(result.Sources)
-	for _, source := range []string{envSourceProcess, envSourceFile, envSourceShell} {
-		keys := visible[source]
-		if len(keys) == 0 {
-			continue
+	if key := providerEnvironmentKey(strings.TrimSpace(provider)); key != "" {
+		source := result.SourceFor(key)
+		if source == "" {
+			source = "GUI process"
 		}
-		lines = append(lines, source+": "+strings.Join(keys, ", "))
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			lines = append(lines, key+": visible from "+source)
+		} else {
+			lines = append(lines, key+": not visible")
+		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+func providerEnvironmentKey(provider string) string {
+	switch provider {
+	case connector.OpenaiProvider:
+		return "OPENAI_API_KEY"
+	case connector.AnthropicProvider:
+		return "ANTHROPIC_API_KEY"
+	case connector.GoogleProvider:
+		return "GEMINI_API_KEY"
+	case connector.MistralProvider:
+		return "MISTRAL_API_KEY"
+	case connector.MiMoProvider:
+		return "MIMO_API_KEY"
+	case connector.LlamaProvider:
+		return "YZMA_LIB"
+	case connector.OllamaProvider:
+		return "OLLAMA_HOST"
+	case connector.BedrockProvider:
+		return "AWS_REGION"
+	default:
+		return ""
+	}
 }
 
 func (p *popupWindow) resizeInput(value string) {

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -503,12 +503,21 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 	)
 	environmentLabel = widget.NewLabel(environmentSummaryText(currentEnvResult, options.InitialProvider))
 	environmentLabel.Wrapping = fyne.TextWrapWord
-	reloadEnvButton := widget.NewButton("Reload", func() {
+	var reloadEnvButton *widget.Button
+	reloadEnvButton = widget.NewButton("Reload", func() {
 		if options.OnReloadEnv == nil {
 			return
 		}
-		currentEnvResult = options.OnReloadEnv()
-		updateHints(providerInput.Text)
+		reloadEnvButton.Disable()
+		environmentLabel.SetText("Reloading environment...")
+		go func() {
+			reloaded := options.OnReloadEnv()
+			fyne.Do(func() {
+				currentEnvResult = reloaded
+				updateHints(providerInput.Text)
+				reloadEnvButton.Enable()
+			})
+		}()
 	})
 	environmentBox := container.NewVBox(
 		widget.NewLabelWithStyle("Environment", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"image/color"
+	"slices"
 	"strings"
 
 	"fyne.io/fyne/v2"
@@ -81,11 +82,12 @@ type providerStatusIcon struct {
 }
 
 type settingsDialogOptions struct {
-	InitialProvider string
-	InitialModel    string
-	Version         string
-	EnvResult       EnvironmentLoadResult
-	OnSave          func(provider, model string) error
+	InitialProvider  string
+	InitialModel     string
+	Version          string
+	EnvResult        EnvironmentLoadResult
+	ModelForProvider func(provider string) string
+	OnSave           func(provider, model string) error
 }
 
 func newProviderStatusIcon(c fyne.Canvas) *providerStatusIcon {
@@ -474,6 +476,11 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 	updateHints := func(provider string) {
 		provider = strings.TrimSpace(provider)
 		providerStatus.setStatus(providerReadinessStatusWithEnvironment(provider, currentEnvResult))
+		if options.ModelForProvider != nil && slices.Contains(connector.SupportedProviders(), provider) {
+			if model := strings.TrimSpace(options.ModelForProvider(provider)); model != "" {
+				modelEntry.SetText(model)
+			}
+		}
 		if def := connector.DefaultModelFor(provider); def != "" {
 			modelHint.SetText("Default model: " + def)
 		} else {

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -2,7 +2,6 @@ package gui
 
 import (
 	"image/color"
-	"os"
 	"strings"
 
 	"fyne.io/fyne/v2"
@@ -86,7 +85,6 @@ type settingsDialogOptions struct {
 	InitialModel    string
 	Version         string
 	EnvResult       EnvironmentLoadResult
-	OnReloadEnv     func() EnvironmentLoadResult
 	OnSave          func(provider, model string) error
 }
 
@@ -472,14 +470,10 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 	}
 	modelHint := newHint()
 	providerStatus := newProviderStatusIcon(p.window.Canvas())
-	var environmentLabel *widget.Label
 
 	updateHints := func(provider string) {
 		provider = strings.TrimSpace(provider)
 		providerStatus.setStatus(providerReadinessStatusWithEnvironment(provider, currentEnvResult))
-		if environmentLabel != nil {
-			environmentLabel.SetText(environmentSummaryText(currentEnvResult, provider))
-		}
 		if def := connector.DefaultModelFor(provider); def != "" {
 			modelHint.SetText("Default model: " + def)
 		} else {
@@ -501,28 +495,11 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 		modelLabel, modelEntry,
 		widget.NewLabel(""), modelHint,
 	)
-	environmentLabel = widget.NewLabel(environmentSummaryText(currentEnvResult, options.InitialProvider))
+	environmentLabel := widget.NewLabel(environmentSummaryText(currentEnvResult))
 	environmentLabel.Wrapping = fyne.TextWrapWord
-	var reloadEnvButton *widget.Button
-	reloadEnvButton = widget.NewButton("Reload", func() {
-		if options.OnReloadEnv == nil {
-			return
-		}
-		reloadEnvButton.Disable()
-		environmentLabel.SetText("Reloading environment...")
-		go func() {
-			reloaded := options.OnReloadEnv()
-			fyne.Do(func() {
-				currentEnvResult = reloaded
-				updateHints(providerInput.Text)
-				reloadEnvButton.Enable()
-			})
-		}()
-	})
 	environmentBox := container.NewVBox(
 		widget.NewLabelWithStyle("Environment", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		environmentLabel,
-		container.NewHBox(reloadEnvButton, layout.NewSpacer()),
 	)
 	var dlg dialog.Dialog
 	saveButton := widget.NewButton("Save", func() {
@@ -560,7 +537,7 @@ func (p *popupWindow) showSettingsDialog(options settingsDialogOptions) {
 	dlg.Show()
 }
 
-func environmentSummaryText(result EnvironmentLoadResult, provider string) string {
+func environmentSummaryText(result EnvironmentLoadResult) string {
 	lines := []string{}
 	fileStatus := "missing"
 	if result.EnvFileLoaded {
@@ -578,48 +555,13 @@ func environmentSummaryText(result EnvironmentLoadResult, provider string) strin
 	case !result.ShellEnabled:
 		lines = append(lines, "Shell import: disabled")
 	case result.ShellLoaded:
-		lines = append(lines, "Shell import: loaded ("+result.Shell+", "+result.ShellDuration.Truncate(10_000_000).String()+")")
+		lines = append(lines, "Shell import: loaded")
 	case result.ShellError != nil:
 		lines = append(lines, "Shell import: failed: "+result.ShellError.Error())
 	default:
 		lines = append(lines, "Shell import: not loaded")
 	}
-
-	if key := providerEnvironmentKey(strings.TrimSpace(provider)); key != "" {
-		source := result.SourceFor(key)
-		if source == "" {
-			source = "GUI process"
-		}
-		if strings.TrimSpace(os.Getenv(key)) != "" {
-			lines = append(lines, key+": visible from "+source)
-		} else {
-			lines = append(lines, key+": not visible")
-		}
-	}
 	return strings.Join(lines, "\n")
-}
-
-func providerEnvironmentKey(provider string) string {
-	switch provider {
-	case connector.OpenaiProvider:
-		return "OPENAI_API_KEY"
-	case connector.AnthropicProvider:
-		return "ANTHROPIC_API_KEY"
-	case connector.GoogleProvider:
-		return "GEMINI_API_KEY"
-	case connector.MistralProvider:
-		return "MISTRAL_API_KEY"
-	case connector.MiMoProvider:
-		return "MIMO_API_KEY"
-	case connector.LlamaProvider:
-		return "YZMA_LIB"
-	case connector.OllamaProvider:
-		return "OLLAMA_HOST"
-	case connector.BedrockProvider:
-		return "AWS_REGION"
-	default:
-		return ""
-	}
 }
 
 func (p *popupWindow) resizeInput(value string) {

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -64,6 +64,7 @@ type popupWindow struct {
 	onSettings   func()
 	onTest       func()
 	onInput      func(string)
+	onQuit       func()
 }
 
 type popupEntry struct {
@@ -359,6 +360,11 @@ func newPopupWindow(app fyne.App, devMode bool) *popupWindow {
 
 	window.Canvas().AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyL, Modifier: fyne.KeyModifierShortcutDefault}, func(shortcut fyne.Shortcut) {
 		p.window.Canvas().Focus(p.input)
+	})
+	window.Canvas().AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyQ, Modifier: fyne.KeyModifierShortcutDefault}, func(shortcut fyne.Shortcut) {
+		if p.onQuit != nil {
+			p.onQuit()
+		}
 	})
 
 	return p

--- a/internal/gui/settings_validation.go
+++ b/internal/gui/settings_validation.go
@@ -75,10 +75,14 @@ type providerReadiness struct {
 }
 
 func providerReadinessStatus(provider string) providerReadiness {
+	return providerReadinessStatusWithEnvironment(provider, EnvironmentLoadResult{})
+}
+
+func providerReadinessStatusWithEnvironment(provider string, envResult EnvironmentLoadResult) providerReadiness {
 	switch provider {
 	case connector.OpenaiProvider:
 		if os.Getenv("OPENAI_API_KEY") != "" {
-			return providerReadiness{Available: true, Message: "Available: OPENAI_API_KEY is visible to the GUI process."}
+			return providerReadiness{Available: true, Message: availableEnvMessage("OPENAI_API_KEY", envResult)}
 		}
 		status, err := auth.NewManager().Status(provider)
 		if err == nil && status.Configured {
@@ -92,16 +96,16 @@ func providerReadinessStatus(provider string) providerReadiness {
 		}
 		return providerReadiness{Message: "Unavailable: no stored Codex OAuth login is configured."}
 	case connector.AnthropicProvider:
-		return envProviderReadiness("Anthropic", "ANTHROPIC_API_KEY")
+		return envProviderReadinessWithEnvironment("Anthropic", "ANTHROPIC_API_KEY", envResult)
 	case connector.GoogleProvider:
-		return envProviderReadiness("Google", "GEMINI_API_KEY")
+		return envProviderReadinessWithEnvironment("Google", "GEMINI_API_KEY", envResult)
 	case connector.MistralProvider:
-		return envProviderReadiness("Mistral", "MISTRAL_API_KEY")
+		return envProviderReadinessWithEnvironment("Mistral", "MISTRAL_API_KEY", envResult)
 	case connector.MiMoProvider:
-		return envProviderReadiness("MiMo", "MIMO_API_KEY")
+		return envProviderReadinessWithEnvironment("MiMo", "MIMO_API_KEY", envResult)
 	case connector.LlamaProvider:
 		if os.Getenv("YZMA_LIB") != "" {
-			return providerReadiness{Available: true, Message: "Available: YZMA_LIB is visible to the GUI process."}
+			return providerReadiness{Available: true, Message: availableEnvMessage("YZMA_LIB", envResult)}
 		}
 		return providerReadiness{Message: "Unavailable: YZMA_LIB is not visible to the GUI process."}
 	case connector.OllamaProvider:
@@ -120,10 +124,21 @@ func providerReadinessStatus(provider string) providerReadiness {
 }
 
 func envProviderReadiness(displayName, envVar string) providerReadiness {
+	return envProviderReadinessWithEnvironment(displayName, envVar, EnvironmentLoadResult{})
+}
+
+func envProviderReadinessWithEnvironment(displayName, envVar string, envResult EnvironmentLoadResult) providerReadiness {
 	if os.Getenv(envVar) != "" {
-		return providerReadiness{Available: true, Message: fmt.Sprintf("Available: %s is visible to the GUI process.", envVar)}
+		return providerReadiness{Available: true, Message: availableEnvMessage(envVar, envResult)}
 	}
 	return providerReadiness{Message: fmt.Sprintf("Unavailable: %s is not visible to the GUI process. %s requires it.", envVar, displayName)}
+}
+
+func availableEnvMessage(envVar string, envResult EnvironmentLoadResult) string {
+	if source := envResult.SourceFor(envVar); source != "" {
+		return fmt.Sprintf("Available: %s is visible from %s.", envVar, source)
+	}
+	return fmt.Sprintf("Available: %s is visible to the GUI process.", envVar)
 }
 
 func explainRuntimeError(provider string, err error) string {

--- a/internal/platform/ipc.go
+++ b/internal/platform/ipc.go
@@ -87,6 +87,9 @@ func Send(ctx context.Context, socketPath, command string) error {
 		return err
 	}
 	defer conn.Close()
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
 
 	if _, err := fmt.Fprintf(conn, "%s\n", command); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- add GUI-specific environment loading from process env, a hidden app env file, and optional shell import
- show environment source diagnostics and reload support in GUI settings
- document .gui.env usage and add tests for precedence, reload, and config defaults

## Tests
- go test ./...