### PR TITLE
fix(gui): render errors in response panel

### DIFF
--- a/internal/gui/actions.go
+++ b/internal/gui/actions.go
@@ -41,7 +41,7 @@ func (g *App) submit() {
 	if err != nil {
 		g.stopIndicatorAnimation()
 		g.state.clearRunning()
-		g.state.errorText = err.Error()
+		g.state.errorText = runtimeErrorMessage(err)
 		g.render()
 		return
 	}
@@ -56,10 +56,7 @@ func (g *App) cancel() {
 }
 
 func (g *App) copyOutput() {
-	text := g.state.output
-	if text == "" {
-		text = g.state.question
-	}
+	text := responseCopyText(g.state)
 	if text != "" {
 		g.fyneApp.Clipboard().SetContent(text)
 	}

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -192,7 +192,7 @@ func (g *App) render() {
 	g.popup.questionLabel.Text = g.state.question
 	g.popup.questionLabel.Refresh()
 	if !g.state.isRunning {
-		g.renderOutput()
+		g.renderResponse()
 	}
 	g.popup.modelLabel.SetText(g.cfg.GetDefaultProvider() + " / " + g.cfg.GetDefaultModelId())
 	showAnswer := g.state.output != "" || g.state.isRunning || g.state.errorText != ""
@@ -212,6 +212,11 @@ func (g *App) render() {
 	} else {
 		g.popup.answerHeader.Hide()
 	}
+	if g.state.errorText != "" {
+		g.popup.answerHeading.SetText("Error")
+	} else {
+		g.popup.answerHeading.SetText("Response")
+	}
 	if g.state.showRequest {
 		g.popup.requestHeading.Show()
 		g.popup.questionCard.Show()
@@ -220,11 +225,7 @@ func (g *App) render() {
 		g.popup.questionCard.Hide()
 	}
 
-	status := g.state.status
-	if g.state.errorText != "" {
-		status = g.state.errorText
-	}
-	g.popup.setStatus(status, g.state.isRunning, g.state.spinnerFrame)
+	g.popup.setStatus(displayStatus(g.state), g.state.isRunning, g.state.spinnerFrame)
 
 	if g.state.isRunning {
 		g.popup.actionButton.SetText("Cancel")
@@ -234,7 +235,7 @@ func (g *App) render() {
 		g.popup.actionButton.Enable()
 	}
 
-	if g.state.output != "" {
+	if hasCopyableResponse(g.state) {
 		g.popup.copyButton.Enable()
 	} else {
 		g.popup.copyButton.Disable()
@@ -271,36 +272,39 @@ func (g *App) openSettings() {
 	})
 }
 
-// openTestMenu shows the dev-only test dialog. Each entry injects a canned
-// response so rendering can be exercised without a live model call.
-func (g *App) openTestMenu() {
-	g.popup.showTestDialog([]devTest{
-		{
-			name: "Exhaustive markdown",
-			run: func() {
-				g.showCannedOutput("Markdown feature test", exhaustiveMarkdown)
-			},
-		},
-	})
-}
-
-// showCannedOutput places static content in the response area as if a run had
-// completed, without contacting any provider.
-func (g *App) showCannedOutput(question, output string) {
-	if g.state.isRunning {
-		g.cancel()
+// renderResponse pushes the current response or error into the view.
+func (g *App) renderResponse() {
+	if g.state.errorText != "" {
+		g.popup.setError(g.state.errorText)
+		return
 	}
-	g.state.resetOutput()
-	g.state.question = question
-	g.state.output = output
-	g.state.showRequest = true
-	g.renderOutput()
-	g.render()
+	g.popup.setOutput(g.state.output)
 }
 
 // renderOutput pushes the current response into the view.
 func (g *App) renderOutput() {
 	g.popup.setOutput(g.state.output)
+}
+
+func displayStatus(s *state) string {
+	if s.errorText != "" {
+		return "Error"
+	}
+	return s.status
+}
+
+func hasCopyableResponse(s *state) bool {
+	return s.errorText != "" || s.output != ""
+}
+
+func responseCopyText(s *state) string {
+	if s.errorText != "" {
+		return s.errorText
+	}
+	if s.output != "" {
+		return s.output
+	}
+	return s.question
 }
 
 func memoryPath() string {

--- a/internal/gui/app_test.go
+++ b/internal/gui/app_test.go
@@ -1,0 +1,55 @@
+package gui
+
+import "testing"
+
+func TestDisplayStatusUsesShortErrorStatus(t *testing.T) {
+	s := &state{
+		status:    "thinking",
+		errorText: "provider openai request failed with a long response body",
+	}
+
+	if got := displayStatus(s); got != "Error" {
+		t.Fatalf("displayStatus() = %q, want %q", got, "Error")
+	}
+}
+
+func TestDisplayStatusUsesNormalStatusWithoutError(t *testing.T) {
+	s := &state{status: "responding"}
+
+	if got := displayStatus(s); got != "responding" {
+		t.Fatalf("displayStatus() = %q, want %q", got, "responding")
+	}
+}
+
+func TestResponseCopyTextPrioritizesDisplayedError(t *testing.T) {
+	s := &state{
+		question:  "test question",
+		output:    "partial streamed output",
+		errorText: "provider failed with full error text",
+	}
+
+	if got := responseCopyText(s); got != s.errorText {
+		t.Fatalf("responseCopyText() = %q, want error %q", got, s.errorText)
+	}
+}
+
+func TestResponseCopyTextFallsBackToOutputThenQuestion(t *testing.T) {
+	withOutput := &state{question: "question", output: "answer"}
+	if got := responseCopyText(withOutput); got != "answer" {
+		t.Fatalf("responseCopyText(withOutput) = %q, want %q", got, "answer")
+	}
+
+	withQuestion := &state{question: "question"}
+	if got := responseCopyText(withQuestion); got != "question" {
+		t.Fatalf("responseCopyText(withQuestion) = %q, want %q", got, "question")
+	}
+}
+
+func TestHasCopyableResponseIncludesErrors(t *testing.T) {
+	if !hasCopyableResponse(&state{errorText: "provider failed"}) {
+		t.Fatal("hasCopyableResponse() should be true for errors")
+	}
+	if hasCopyableResponse(&state{question: "question only"}) {
+		t.Fatal("hasCopyableResponse() should be false without output or error")
+	}
+}

--- a/internal/gui/dev_menu.go
+++ b/internal/gui/dev_menu.go
@@ -1,0 +1,72 @@
+package gui
+
+import (
+	"context"
+
+	appservice "github.com/laszukdawid/terminal-agent/internal/app"
+)
+
+// openTestMenu shows the dev-only test dialog. Each entry exercises a GUI
+// rendering path without requiring the user to manually reproduce it.
+func (g *App) openTestMenu() {
+	g.popup.showTestDialog([]devTest{
+		{
+			name: "Exhaustive markdown",
+			run: func() {
+				g.showCannedOutput("Markdown feature test", exhaustiveMarkdown)
+			},
+		},
+		{
+			name: "Invalid provider error",
+			run:  g.showInvalidProviderError,
+		},
+	})
+}
+
+// showCannedOutput places static content in the response area as if a run had
+// completed, without contacting any provider. It is useful for renderer-only
+// scenarios such as markdown coverage.
+func (g *App) showCannedOutput(question, output string) {
+	if g.state.isRunning {
+		g.cancel()
+	}
+	g.state.resetOutput()
+	g.state.question = question
+	g.state.output = output
+	g.state.showRequest = true
+	g.renderResponse()
+	g.render()
+}
+
+// showInvalidProviderError exercises the same error path used by real ask
+// requests without changing the user's saved provider settings.
+func (g *App) showInvalidProviderError() {
+	if g.state.isRunning {
+		g.cancel()
+	}
+
+	question := "Dev test: invalid provider"
+	g.state.resetOutput()
+	g.state.question = question
+	g.state.showRequest = true
+
+	events, err := g.service.AskEvents(context.Background(), appservice.AskRequest{
+		Message:    question,
+		Provider:   "terminal-agent-dev-invalid-provider",
+		Model:      g.cfg.GetDefaultModelId(),
+		UseMemory:  g.cfg.GetMemory(),
+		MemoryPath: memoryPath(),
+		WorkingDir: g.cfg.GetWorkingDir(),
+		Stream:     true,
+		Config:     g.cfg,
+	})
+	if err != nil {
+		g.state.errorText = runtimeErrorMessage(err)
+		g.renderResponse()
+		g.render()
+		return
+	}
+
+	go g.consumeAskEvents(events)
+	g.render()
+}

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -43,8 +43,12 @@ type popupWindow struct {
 	questionCard    fyne.CanvasObject
 	questionLabel   *canvas.Text
 	outputField     *widget.RichText
+	outputBody      fyne.CanvasObject
+	errorLabel      *widget.Label
+	errorBody       fyne.CanvasObject
 	outputScroll    *container.Scroll
 	lastRendered    string
+	lastError       string
 	headerStatus    *widget.Label
 	headerBrain     *canvas.Text
 	headerSpinner   *canvas.Text
@@ -225,7 +229,13 @@ func newPopupWindow(app fyne.App, devMode bool) *popupWindow {
 	outputField := widget.NewRichText()
 	outputField.Wrapping = fyne.TextWrapWord
 	outputBody := withBackground(outputField, color.NRGBA{R: 248, G: 249, B: 251, A: 255})
-	outputScroll := container.NewVScroll(outputBody)
+	errorLabel := widget.NewLabel("")
+	errorLabel.Wrapping = fyne.TextWrapBreak
+	errorLabel.Importance = widget.DangerImportance
+	errorBody := withBackground(errorLabel, color.NRGBA{R: 255, G: 245, B: 245, A: 255})
+	errorBody.Hide()
+	outputStack := container.NewStack(outputBody, errorBody)
+	outputScroll := container.NewVScroll(outputStack)
 	outputScroll.SetMinSize(fyne.NewSize(0, compactOutputHeight))
 
 	headerStatus := widget.NewLabelWithStyle("", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
@@ -307,6 +317,9 @@ func newPopupWindow(app fyne.App, devMode bool) *popupWindow {
 		answerMeta:      answerMeta,
 		questionLabel:   questionLabel,
 		outputField:     outputField,
+		outputBody:      outputBody,
+		errorLabel:      errorLabel,
+		errorBody:       errorBody,
 		outputScroll:    outputScroll,
 		headerStatus:    headerStatus,
 		headerBrain:     headerBrain,
@@ -371,12 +384,24 @@ func newPopupWindow(app fyne.App, devMode bool) *popupWindow {
 }
 
 func (p *popupWindow) setOutput(content string) {
+	p.errorBody.Hide()
+	p.outputBody.Show()
 	if p.lastRendered == content {
 		return
 	}
 	p.lastRendered = content
 	p.outputField.Segments = renderMarkdown(unwrapMarkdownFence(content))
 	p.outputField.Refresh()
+}
+
+func (p *popupWindow) setError(content string) {
+	p.outputBody.Hide()
+	p.errorBody.Show()
+	if p.lastError == content {
+		return
+	}
+	p.lastError = content
+	p.errorLabel.SetText(content)
 }
 
 // unwrapMarkdownFence strips an outer ```markdown or ```md code fence so

--- a/internal/gui/presenter.go
+++ b/internal/gui/presenter.go
@@ -32,7 +32,7 @@ func (g *App) consumeAskEvents(events <-chan appservice.Event) {
 					g.state.errorText = ""
 					g.state.status = "Canceled."
 				} else {
-					g.state.errorText = explainRuntimeError(g.cfg.GetDefaultProvider(), eventCopy.Err)
+					g.state.errorText = runtimeErrorMessage(eventCopy.Err)
 				}
 				g.state.clearRunning()
 			}

--- a/internal/gui/settings_validation.go
+++ b/internal/gui/settings_validation.go
@@ -141,7 +141,7 @@ func availableEnvMessage(envVar string, envResult EnvironmentLoadResult) string 
 	return fmt.Sprintf("Available: %s is visible to the GUI process.", envVar)
 }
 
-func explainRuntimeError(provider string, err error) string {
+func runtimeErrorMessage(err error) string {
 	if err == nil {
 		return ""
 	}
@@ -153,30 +153,6 @@ func explainRuntimeError(provider string, err error) string {
 	if message == "" {
 		return ""
 	}
-
-	hint := providerSetupHint(provider)
-	lower := strings.ToLower(message)
-	switch {
-	case strings.Contains(lower, "unsupported provider"):
-		return fmt.Sprintf("%s Supported providers: %s.", message, strings.Join(connector.SupportedProviders(), ", "))
-	case strings.Contains(lower, "api key"), strings.Contains(lower, "authenticate"), strings.Contains(lower, "authentication"):
-		if hint != "" {
-			return hint
-		}
-	case strings.Contains(lower, "oauth login has expired"), strings.Contains(lower, "agent auth login codex' again"):
-		if provider == connector.CodexProvider {
-			return "Stored Codex login has expired. Run 'agent auth login codex' again."
-		}
-	case strings.Contains(lower, "status code: 401"), strings.Contains(lower, "status code 401"):
-		if hint != "" {
-			return hint
-		}
-	case strings.Contains(lower, "no such host"), strings.Contains(lower, "connection refused"):
-		if provider == connector.OllamaProvider {
-			return "Could not reach Ollama. Start Ollama locally or set OLLAMA_HOST to the correct server URL."
-		}
-	}
-
 	return message
 }
 

--- a/internal/gui/settings_validation_test.go
+++ b/internal/gui/settings_validation_test.go
@@ -1,6 +1,8 @@
 package gui
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/laszukdawid/terminal-agent/internal/connector"
@@ -91,4 +93,20 @@ func TestFilterProviders(t *testing.T) {
 	assert.Equal(t, all, filterProviders(all, ""))
 	// No match returns empty.
 	assert.Empty(t, filterProviders(all, "zzz"))
+}
+
+func TestRuntimeErrorMessageReturnsTrimmedProviderText(t *testing.T) {
+	err := errors.New("  provider openai request failed: {\"error\":{\"code\":\"insufficient_quota\"}}  ")
+
+	got := runtimeErrorMessage(err)
+	want := "provider openai request failed: {\"error\":{\"code\":\"insufficient_quota\"}}"
+	if got != want {
+		t.Fatalf("runtimeErrorMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRuntimeErrorMessageSuppressesCancellation(t *testing.T) {
+	if got := runtimeErrorMessage(context.Canceled); got != "" {
+		t.Fatalf("runtimeErrorMessage(context.Canceled) = %q, want empty", got)
+	}
 }


### PR DESCRIPTION
## Summary
- render GUI runtime/setup errors in a wrapped response-panel error view instead of the header status
- keep the header status concise and make copy behavior use the displayed error text
- move dev test menu scenarios into a dedicated module and add an invalid-provider error scenario

## Tests
- go test ./internal/gui
- go test ./cmd/agent-gui
- task test:unit