### PR TITLE
Show commands for streamed task output

### DIFF
--- a/internal/commands/task_cmd.go
+++ b/internal/commands/task_cmd.go
@@ -98,26 +98,21 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 			}
 			progress := newTaskProgressPrinter(cmd.ErrOrStderr(), progressConfig)
 			defer progress.Clear()
-			liveOutput := newTaskLiveOutputLimiter(config.GetTaskLiveOutputLimit(), 120)
+			liveOutput := newTaskLiveOutputPrinter(cmd.OutOrStdout(), progress, config.GetTaskLiveOutputLimit())
 
 			result := app.TaskResult{Request: userRequest}
-			printedStreamedToolOutput := false
-			lastStreamChunkEndedWithNewline := true
 			for event := range events {
 				switch event.Type {
 				case app.EventTaskStatus:
+					if event.Status == string(agent.TaskStatusRunningTool) {
+						liveOutput.BeginTool(event)
+					}
 					progress.Print(event.Text)
 				case app.EventToolProgress:
 					progress.Print(formatToolProgress(event))
 				case app.EventOutputDelta:
 					if printFlag {
-						chunk := liveOutput.Filter(event.Text)
-						if chunk != "" {
-							progress.Clear()
-							printedStreamedToolOutput = true
-							lastStreamChunkEndedWithNewline = strings.HasSuffix(chunk, "\n")
-							cmd.Print(chunk)
-						}
+						liveOutput.PrintDelta(event.Text)
 					}
 				case app.EventWarning:
 					if event.Text != "" {
@@ -144,7 +139,7 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 					}
 				case app.EventCompleted:
 					result.Response = event.FinalOutput
-					if !printedStreamedToolOutput {
+					if !liveOutput.Printed() {
 						result.RawOutput = event.RawOutput
 					}
 					result.RawOutputTool = event.RawOutputTool
@@ -158,12 +153,12 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 
 			response := result.Response
 
-			if printedStreamedToolOutput && result.DirectRawOutput {
+			if liveOutput.Printed() && result.DirectRawOutput {
 				response = ""
 			}
 
 			if printFlag && response != "" {
-				if printedStreamedToolOutput && !lastStreamChunkEndedWithNewline {
+				if liveOutput.NeedsNewlineBeforeFinal() {
 					cmd.Print("\n")
 				}
 				plain, _ := flags.GetBool("plain")
@@ -206,77 +201,6 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 
 	cmd.Flags().String("progress", "auto", "Show task progress on stderr: auto, always, or never")
 	return cmd
-}
-
-type taskLiveOutputLimiter struct {
-	maxLines            int
-	maxLineChars        int
-	lines               int
-	charsWithoutNewline int
-	sawNewline          bool
-	truncated           bool
-	truncationAnnounced bool
-}
-
-func newTaskLiveOutputLimiter(maxLines int, maxLineChars int) *taskLiveOutputLimiter {
-	return &taskLiveOutputLimiter{maxLines: maxLines, maxLineChars: maxLineChars}
-}
-
-func (l *taskLiveOutputLimiter) Filter(chunk string) string {
-	if chunk == "" || l.truncationAnnounced {
-		return ""
-	}
-	if l.maxLines == 0 {
-		return chunk
-	}
-
-	var out strings.Builder
-	startLines := l.lines
-	knownChunkLines := countOutputLines(chunk)
-	for _, r := range chunk {
-		if l.lines >= l.maxLines || (!l.sawNewline && l.charsWithoutNewline >= l.maxLines*l.maxLineChars) {
-			l.truncated = true
-			break
-		}
-
-		out.WriteRune(r)
-		if r == '\n' {
-			l.sawNewline = true
-			l.lines++
-			continue
-		}
-		if !l.sawNewline {
-			l.charsWithoutNewline++
-		}
-	}
-
-	if l.truncated {
-		l.truncationAnnounced = true
-		if out.Len() > 0 && !strings.HasSuffix(out.String(), "\n") {
-			out.WriteByte('\n')
-		}
-		out.WriteString(formatLiveOutputTruncation(l.maxLines, startLines+knownChunkLines, l.sawNewline))
-	}
-
-	return out.String()
-}
-
-func countOutputLines(s string) int {
-	if s == "" {
-		return 0
-	}
-	lines := strings.Count(s, "\n")
-	if !strings.HasSuffix(s, "\n") {
-		lines++
-	}
-	return lines
-}
-
-func formatLiveOutputTruncation(shown int, totalLines int, lineMode bool) string {
-	if lineMode && totalLines > shown {
-		return fmt.Sprintf("[tool output truncated: %d out of %d lines]\n", shown, totalLines)
-	}
-	return fmt.Sprintf("[tool output truncated: %d lines shown]\n", shown)
 }
 
 type taskProgressPrinter struct {

--- a/internal/commands/task_cmd_test.go
+++ b/internal/commands/task_cmd_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/laszukdawid/terminal-agent/internal/agent"
 	"github.com/laszukdawid/terminal-agent/internal/app"
 	"github.com/laszukdawid/terminal-agent/internal/config"
 	"github.com/laszukdawid/terminal-agent/internal/tools"
@@ -198,6 +199,15 @@ func TestTaskCommandStreamedOutput(t *testing.T) {
 			want:   "live output\ndone",
 		},
 		{
+			name: "prints command before streamed output",
+			args: []string{"--plain", "inspect", "repo"},
+			events: []app.Event{
+				{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running unix...", ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "git status --short"}},
+				{Type: app.EventOutputDelta, Text: "M file.go\n", ToolName: tools.ToolNameUnix},
+			},
+			want: "Command: git status --short\nM file.go\ndone",
+		},
+		{
 			name:        "limits streamed output by default",
 			args:        []string{"--plain", "inspect", "repo"},
 			events:      []app.Event{{Type: app.EventOutputDelta, Text: "1\n2\n3\n4\n5\n6\n7\n8\n"}},
@@ -219,6 +229,26 @@ func TestTaskCommandStreamedOutput(t *testing.T) {
 			events:      []app.Event{{Type: app.EventOutputDelta, Text: "1\n2\n3\n4\n5\n6\n7\n"}},
 			contains:    []string{"7\n"},
 			notContains: []string{"truncated"},
+		},
+		{
+			name: "resets streamed output limit for each tool execution",
+			cfg:  taskLiveOutputLimitConfig(2),
+			args: []string{"--plain", "inspect", "repo"},
+			events: []app.Event{
+				{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running unix...", ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "printf '1\\n2\\n3\\n'"}},
+				{Type: app.EventOutputDelta, Text: "1\n2\n3\n", ToolName: tools.ToolNameUnix},
+				{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running python...", ToolName: tools.ToolNamePython, ToolInput: map[string]any{"code": "print('a')\nprint('b')\nprint('c')"}},
+				{Type: app.EventOutputDelta, Text: "a\nb\nc\n", ToolName: tools.ToolNamePython},
+			},
+			contains: []string{
+				"Command: printf '1\\n2\\n3\\n'\n",
+				"1\n2\n",
+				"tool output truncated: 2 out of 3 lines",
+				"Command: print('a')\nprint('b')\nprint('c')\n",
+				"a\nb\n",
+				"done",
+			},
+			notContains: []string{"3\n", "c\n"},
 		},
 	}
 
@@ -324,6 +354,62 @@ func TestTaskLiveOutputLimiter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFormatTaskStreamedCommand(t *testing.T) {
+	tests := []struct {
+		name  string
+		event app.Event
+		want  string
+	}{
+		{
+			name:  "unix command",
+			event: app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "git status --short"}},
+			want:  "git status --short",
+		},
+		{
+			name:  "python code",
+			event: app.Event{ToolName: tools.ToolNamePython, ToolInput: map[string]any{"code": "print('hello')"}},
+			want:  "print('hello')",
+		},
+		{
+			name:  "python path",
+			event: app.Event{ToolName: tools.ToolNamePython, ToolInput: map[string]any{"path": "scripts/report.py"}},
+			want:  "scripts/report.py",
+		},
+		{
+			name:  "fallback action expression",
+			event: app.Event{ToolName: tools.ToolNameFileSearch, ToolInput: map[string]any{"name_pattern": "*.go"}},
+			want:  `file_search(name_pattern="*.go")`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatTaskStreamedCommand(tt.event))
+		})
+	}
+}
+
+func TestTaskLiveOutputPrinter(t *testing.T) {
+	progressOutput := &bytes.Buffer{}
+	progress := newTaskProgressPrinter(progressOutput, taskProgressConfig{})
+	output := &bytes.Buffer{}
+	printer := newTaskLiveOutputPrinter(output, progress, 2)
+
+	printer.BeginTool(app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "printf one"}})
+	printer.PrintDelta("one")
+
+	assert.True(t, printer.Printed())
+	assert.True(t, printer.NeedsNewlineBeforeFinal())
+	assert.Equal(t, "Command: printf one\none", output.String())
+
+	printer.BeginTool(app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "printf 'a\\nb\\nc\\n'"}})
+	printer.PrintDelta("a\nb\nc\n")
+
+	assert.Contains(t, output.String(), "one\nCommand: printf 'a\\nb\\nc\\n'\na\nb\n")
+	assert.Contains(t, output.String(), "[tool output truncated: 2 out of 3 lines]\n")
+	assert.False(t, printer.NeedsNewlineBeforeFinal())
 }
 
 func TestTaskCommandProgressOutput(t *testing.T) {

--- a/internal/commands/task_live_output.go
+++ b/internal/commands/task_live_output.go
@@ -1,0 +1,157 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/laszukdawid/terminal-agent/internal/agent"
+	"github.com/laszukdawid/terminal-agent/internal/app"
+)
+
+const taskLiveOutputMaxLineChars = 120
+
+type taskLiveOutputPrinter struct {
+	out                   io.Writer
+	progress              *taskProgressPrinter
+	limiter               *taskLiveOutputLimiter
+	command               string
+	commandPrinted        bool
+	printed               bool
+	lastChunkEndedNewline bool
+}
+
+func newTaskLiveOutputPrinter(out io.Writer, progress *taskProgressPrinter, maxLines int) *taskLiveOutputPrinter {
+	if out == nil {
+		out = io.Discard
+	}
+	return &taskLiveOutputPrinter{
+		out:                   out,
+		progress:              progress,
+		limiter:               newTaskLiveOutputLimiter(maxLines, taskLiveOutputMaxLineChars),
+		lastChunkEndedNewline: true,
+	}
+}
+
+func (p *taskLiveOutputPrinter) BeginTool(event app.Event) {
+	p.limiter.Reset()
+	p.command = formatTaskStreamedCommand(event)
+	p.commandPrinted = false
+}
+
+func (p *taskLiveOutputPrinter) PrintDelta(text string) {
+	chunk := p.limiter.Filter(text)
+	if chunk == "" {
+		return
+	}
+
+	if p.progress != nil {
+		p.progress.Clear()
+	}
+	if p.command != "" && !p.commandPrinted {
+		if p.printed && !p.lastChunkEndedNewline {
+			_, _ = fmt.Fprint(p.out, "\n")
+		}
+		_, _ = fmt.Fprintf(p.out, "Command: %s\n", p.command)
+		p.commandPrinted = true
+	}
+	p.printed = true
+	p.lastChunkEndedNewline = strings.HasSuffix(chunk, "\n")
+	_, _ = fmt.Fprint(p.out, chunk)
+}
+
+func (p *taskLiveOutputPrinter) Printed() bool {
+	return p.printed
+}
+
+func (p *taskLiveOutputPrinter) NeedsNewlineBeforeFinal() bool {
+	return p.printed && !p.lastChunkEndedNewline
+}
+
+type taskLiveOutputLimiter struct {
+	maxLines            int
+	maxLineChars        int
+	lines               int
+	charsWithoutNewline int
+	sawNewline          bool
+	truncated           bool
+	truncationAnnounced bool
+}
+
+func newTaskLiveOutputLimiter(maxLines int, maxLineChars int) *taskLiveOutputLimiter {
+	return &taskLiveOutputLimiter{maxLines: maxLines, maxLineChars: maxLineChars}
+}
+
+func (l *taskLiveOutputLimiter) Reset() {
+	l.lines = 0
+	l.charsWithoutNewline = 0
+	l.sawNewline = false
+	l.truncated = false
+	l.truncationAnnounced = false
+}
+
+func (l *taskLiveOutputLimiter) Filter(chunk string) string {
+	if chunk == "" || l.truncationAnnounced {
+		return ""
+	}
+	if l.maxLines == 0 {
+		return chunk
+	}
+
+	var out strings.Builder
+	startLines := l.lines
+	knownChunkLines := countOutputLines(chunk)
+	for _, r := range chunk {
+		if l.lines >= l.maxLines || (!l.sawNewline && l.charsWithoutNewline >= l.maxLines*l.maxLineChars) {
+			l.truncated = true
+			break
+		}
+
+		out.WriteRune(r)
+		if r == '\n' {
+			l.sawNewline = true
+			l.lines++
+			continue
+		}
+		if !l.sawNewline {
+			l.charsWithoutNewline++
+		}
+	}
+
+	if l.truncated {
+		l.truncationAnnounced = true
+		if out.Len() > 0 && !strings.HasSuffix(out.String(), "\n") {
+			out.WriteByte('\n')
+		}
+		out.WriteString(formatLiveOutputTruncation(l.maxLines, startLines+knownChunkLines, l.sawNewline))
+	}
+
+	return out.String()
+}
+
+func countOutputLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	lines := strings.Count(s, "\n")
+	if !strings.HasSuffix(s, "\n") {
+		lines++
+	}
+	return lines
+}
+
+func formatLiveOutputTruncation(shown int, totalLines int, lineMode bool) string {
+	if lineMode && totalLines > shown {
+		return fmt.Sprintf("[tool output truncated: %d out of %d lines]\n", shown, totalLines)
+	}
+	return fmt.Sprintf("[tool output truncated: %d lines shown]\n", shown)
+}
+
+func formatTaskStreamedCommand(event app.Event) string {
+	action := agent.BuildActionString(event.ToolName, event.ToolInput)
+	_, display := agent.ParseToolAndDisplay(action)
+	if display != "" {
+		return display
+	}
+	return action
+}


### PR DESCRIPTION
## Summary
- show the running command before streamed task tool output
- reset live output limits per tool execution
- extract task live-output rendering state into a dedicated helper

## Rational
Task live output was difficult to interpret because the CLI streamed raw tool output without showing which tool invocation produced it. In multi-step tasks, especially when the agent runs several shell commands or scripts, users could see file listings, numeric results, or truncated output blocks without enough context to understand which command generated each block.

The CLI now prints a `Command: ...` header before the first streamed output chunk for each tool execution. This makes live task output self-explanatory while preserving the existing lazy behavior: commands are only shown when there is actual streamed output to display, so tools that produce no live output do not add noise.

This also fixes a related display issue where the live-output truncation limiter was effectively shared across the whole task. Once the first tool execution hit the configured output limit, later tool executions could have their output suppressed. The limiter now resets when a new tool starts, so each tool gets its own bounded live-output window.

While making this change, the task command event loop had accumulated too much live-output state through local variables. That made the behavior harder to reason about and increased the risk of future display regressions. The live-output rendering state is now encapsulated in a dedicated helper that owns command headers, truncation, newline handling, and whether streamed output has already been printed. This keeps `task_cmd.go` focused on event orchestration and makes the display behavior easier to test directly.

Command display formatting now reuses the existing action-display path by composing `BuildActionString` with `ParseToolAndDisplay`. That keeps streamed output headers aligned with confirmation prompts: shell commands show the command itself, Python tools show code or path when available, and other tools fall back to a stable action expression.

## Tests
- go test ./internal/commands
- go test ./internal/agent ./internal/app ./internal/commands
