### PR TITLE
fix: task output display improvements

### DIFF
--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -505,8 +505,7 @@ func (r *taskExecutionState) handleDirectoryChange(response connector.LlmRespons
 }
 
 func (r *taskExecutionState) finalAnswerResult(answer string) TaskRunResult {
-	rawOutput := selectRawTaskOutput(r.successfulOutputs)
-	return TaskRunResult{Response: answer, RawOutput: rawOutput.Output, RawOutputTool: rawOutput.ToolName}
+	return TaskRunResult{Response: answer}
 }
 
 func (a *Agent) buildTaskTools(interaction TaskInteraction) map[string]tools.Tool {

--- a/internal/commands/task_cmd.go
+++ b/internal/commands/task_cmd.go
@@ -139,7 +139,7 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 					}
 				case app.EventCompleted:
 					result.Response = event.FinalOutput
-					if !liveOutput.Printed() || liveOutput.Truncated() {
+					if !liveOutput.PrintedTool(event.RawOutputTool) || liveOutput.TruncatedTool(event.RawOutputTool) {
 						result.RawOutput = event.RawOutput
 					}
 					result.RawOutputTool = event.RawOutputTool
@@ -153,7 +153,7 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 
 			response := result.Response
 
-			if liveOutput.Printed() && !liveOutput.Truncated() && result.DirectRawOutput {
+			if liveOutput.PrintedTool(result.RawOutputTool) && !liveOutput.TruncatedTool(result.RawOutputTool) && result.DirectRawOutput {
 				response = ""
 			}
 

--- a/internal/commands/task_cmd.go
+++ b/internal/commands/task_cmd.go
@@ -139,7 +139,7 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 					}
 				case app.EventCompleted:
 					result.Response = event.FinalOutput
-					if !liveOutput.Printed() {
+					if !liveOutput.Printed() || liveOutput.Truncated() {
 						result.RawOutput = event.RawOutput
 					}
 					result.RawOutputTool = event.RawOutputTool
@@ -153,7 +153,7 @@ func NewTaskCommand(config config.Config) *cobra.Command {
 
 			response := result.Response
 
-			if liveOutput.Printed() && result.DirectRawOutput {
+			if liveOutput.Printed() && !liveOutput.Truncated() && result.DirectRawOutput {
 				response = ""
 			}
 
@@ -428,14 +428,6 @@ func promptTaskConfirmationInteractive(stdin *os.File, stderr *os.File, confirma
 	resp, err := processConfirmationResponse(result.response, result.pattern)
 	if err != nil {
 		return resp, err
-	}
-
-	if resp.Allowed {
-		display := ic.command
-		if display == "" {
-			display = ic.action
-		}
-		fmt.Fprintln(stderr, formatTaskTrace("Executing", display, isTerminalWriter(stderr)))
 	}
 
 	return resp, nil

--- a/internal/commands/task_cmd_test.go
+++ b/internal/commands/task_cmd_test.go
@@ -519,6 +519,84 @@ func TestTaskLiveOutputPrinterPythonTrace(t *testing.T) {
 	assert.NotContains(t, output.String(), "Command:")
 }
 
+func TestTaskLiveOutputPrinterPerToolState(t *testing.T) {
+	t.Run("tracks state independently per tool name", func(t *testing.T) {
+		output := &bytes.Buffer{}
+		printer := newTaskLiveOutputPrinter(output, nil, 2)
+
+		printer.BeginTool(app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "cat big.log"}})
+		printer.PrintDelta("a\nb\nc\n")
+
+		printer.BeginTool(app.Event{ToolName: tools.ToolNamePython, ToolInput: map[string]any{"code": "print(1)"}})
+		printer.PrintDelta("1\n")
+
+		assert.True(t, printer.PrintedTool(tools.ToolNameUnix))
+		assert.True(t, printer.TruncatedTool(tools.ToolNameUnix))
+		assert.True(t, printer.PrintedTool(tools.ToolNamePython))
+		assert.False(t, printer.TruncatedTool(tools.ToolNamePython))
+		assert.False(t, printer.PrintedTool("file_search"), "unknown tool should return false")
+		assert.False(t, printer.TruncatedTool("file_search"))
+	})
+
+	t.Run("tool never printed returns false while global Printed is true", func(t *testing.T) {
+		output := &bytes.Buffer{}
+		printer := newTaskLiveOutputPrinter(output, nil, 10)
+
+		printer.BeginTool(app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "echo hi"}})
+		printer.PrintDelta("hi\n")
+
+		printer.BeginTool(app.Event{ToolName: "file_search", ToolInput: map[string]any{}})
+
+		assert.True(t, printer.Printed(), "task-global printed should be true")
+		assert.False(t, printer.PrintedTool("file_search"), "file_search never streamed output")
+		assert.True(t, printer.PrintedTool(tools.ToolNameUnix))
+	})
+
+	t.Run("OR semantics across multiple invocations of same tool", func(t *testing.T) {
+		output := &bytes.Buffer{}
+		printer := newTaskLiveOutputPrinter(output, nil, 2)
+
+		printer.BeginTool(app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "cat big.log"}})
+		printer.PrintDelta("a\nb\nc\n")
+		assert.True(t, printer.TruncatedTool(tools.ToolNameUnix))
+
+		printer.BeginTool(app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "echo ok"}})
+		printer.PrintDelta("ok\n")
+
+		assert.True(t, printer.TruncatedTool(tools.ToolNameUnix), "OR semantics: truncation from earlier invocation must persist")
+		assert.True(t, printer.PrintedTool(tools.ToolNameUnix))
+	})
+}
+
+func TestTaskCommandDirectRawOutputToolWithNoDeltas(t *testing.T) {
+	output := runTaskCommandWithConfigAndEvents(t, config.NewDefaultConfig(), []string{"--plain", "find", "files"}, func(req app.TaskRequest) []app.Event {
+		return []app.Event{
+			{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running unix...", ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "echo setup"}},
+			{Type: app.EventOutputDelta, Text: "setup\n", ToolName: tools.ToolNameUnix},
+			{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running file_search...", ToolName: "file_search", ToolInput: map[string]any{}},
+			{Type: app.EventCompleted, FinalOutput: "found: a.txt, b.txt", RawOutputTool: "file_search", DirectRawOutput: true},
+		}
+	})
+
+	assert.Contains(t, output, "found: a.txt, b.txt", "DirectRawOutput should appear even when file_search never streamed")
+}
+
+func TestTaskCommandEarlierToolTruncatedPreservesRawOutput(t *testing.T) {
+	rawOutput := "line1\nline2\nline3\nline4\n"
+	output := runTaskCommandWithConfigAndEvents(t, taskLiveOutputLimitConfig(2), []string{"--plain", "analyze", "logs"}, func(req app.TaskRequest) []app.Event {
+		return []app.Event{
+			{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running unix...", ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "cat big.log"}},
+			{Type: app.EventOutputDelta, Text: rawOutput, ToolName: tools.ToolNameUnix},
+			{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running python...", ToolName: tools.ToolNamePython, ToolInput: map[string]any{"code": "print('done')"}},
+			{Type: app.EventOutputDelta, Text: "done\n", ToolName: tools.ToolNamePython},
+			{Type: app.EventCompleted, FinalOutput: "Analysis complete", RawOutput: rawOutput, RawOutputTool: tools.ToolNameUnix},
+		}
+	})
+
+	assert.Contains(t, output, "Raw output from unix:")
+	assert.Contains(t, output, "line3\nline4\n", "truncated unix raw output must be preserved at completion")
+}
+
 func TestFormatTaskTrace(t *testing.T) {
 	assert.Equal(t, "Executing: git diff --cached", formatTaskTrace("Executing", "git diff --cached", false))
 	assert.Equal(t, "\x1b[1;36mExecuting:\x1b[0m \x1b[1mgit diff --cached\x1b[0m", formatTaskTrace("Executing", "git diff --cached", true))

--- a/internal/commands/task_cmd_test.go
+++ b/internal/commands/task_cmd_test.go
@@ -552,7 +552,7 @@ func TestTaskLiveOutputPrinterPerToolState(t *testing.T) {
 		assert.True(t, printer.PrintedTool(tools.ToolNameUnix))
 	})
 
-	t.Run("OR semantics across multiple invocations of same tool", func(t *testing.T) {
+	t.Run("OR semantics for truncated across multiple invocations", func(t *testing.T) {
 		output := &bytes.Buffer{}
 		printer := newTaskLiveOutputPrinter(output, nil, 2)
 
@@ -565,6 +565,19 @@ func TestTaskLiveOutputPrinterPerToolState(t *testing.T) {
 
 		assert.True(t, printer.TruncatedTool(tools.ToolNameUnix), "OR semantics: truncation from earlier invocation must persist")
 		assert.True(t, printer.PrintedTool(tools.ToolNameUnix))
+	})
+
+	t.Run("replace semantics for printed across multiple invocations", func(t *testing.T) {
+		output := &bytes.Buffer{}
+		printer := newTaskLiveOutputPrinter(output, nil, 10)
+
+		printer.BeginTool(app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "echo hi"}})
+		printer.PrintDelta("hi\n")
+		assert.True(t, printer.PrintedTool(tools.ToolNameUnix))
+
+		printer.BeginTool(app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "true"}})
+
+		assert.False(t, printer.PrintedTool(tools.ToolNameUnix), "replace semantics: latest invocation has not printed")
 	})
 }
 
@@ -595,6 +608,22 @@ func TestTaskCommandEarlierToolTruncatedPreservesRawOutput(t *testing.T) {
 
 	assert.Contains(t, output, "Raw output from unix:")
 	assert.Contains(t, output, "line3\nline4\n", "truncated unix raw output must be preserved at completion")
+}
+
+func TestTaskCommandSameToolTruncatedThenShortPreservesRawOutput(t *testing.T) {
+	rawOutput := "line1\nline2\nline3\nline4\n"
+	output := runTaskCommandWithConfigAndEvents(t, taskLiveOutputLimitConfig(2), []string{"--plain", "check", "logs"}, func(req app.TaskRequest) []app.Event {
+		return []app.Event{
+			{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running unix...", ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "cat big.log"}},
+			{Type: app.EventOutputDelta, Text: rawOutput, ToolName: tools.ToolNameUnix},
+			{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running unix...", ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "echo ok"}},
+			{Type: app.EventOutputDelta, Text: "ok\n", ToolName: tools.ToolNameUnix},
+			{Type: app.EventCompleted, FinalOutput: "Summary", RawOutput: rawOutput, RawOutputTool: tools.ToolNameUnix},
+		}
+	})
+
+	assert.Contains(t, output, "Raw output from unix:", "raw output must be preserved when earlier same-tool invocation truncated")
+	assert.Contains(t, output, "line3\nline4\n")
 }
 
 func TestFormatTaskTrace(t *testing.T) {

--- a/internal/commands/task_cmd_test.go
+++ b/internal/commands/task_cmd_test.go
@@ -244,7 +244,7 @@ func TestTaskCommandStreamedOutput(t *testing.T) {
 				"Command: printf '1\\n2\\n3\\n'\n",
 				"1\n2\n",
 				"tool output truncated: 2 out of 3 lines",
-				"Command: print('a')\nprint('b')\nprint('c')\n",
+				"Python:\n  print('a')\n  print('b')\n  print('c')\n",
 				"a\nb\n",
 				"done",
 			},
@@ -386,7 +386,8 @@ func TestFormatTaskStreamedCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, formatTaskStreamedCommand(tt.event))
+			_, display := formatTaskStreamedCommand(tt.event)
+			assert.Equal(t, tt.want, display)
 		})
 	}
 }
@@ -412,6 +413,88 @@ func TestTaskLiveOutputPrinter(t *testing.T) {
 	assert.False(t, printer.NeedsNewlineBeforeFinal())
 }
 
+func TestTaskLiveOutputPrinterTruncated(t *testing.T) {
+	output := &bytes.Buffer{}
+	printer := newTaskLiveOutputPrinter(output, nil, 2)
+
+	printer.BeginTool(app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "echo short"}})
+	printer.PrintDelta("one\ntwo\n")
+	assert.False(t, printer.Truncated(), "exactly at limit should not be truncated")
+
+	printer.BeginTool(app.Event{ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "echo long"}})
+	printer.PrintDelta("a\nb\nc\n")
+	assert.True(t, printer.Truncated(), "exceeding limit should be truncated")
+}
+
+func TestTaskLiveOutputPrinterFinalDisablesTruncation(t *testing.T) {
+	output := &bytes.Buffer{}
+	printer := newTaskLiveOutputPrinter(output, nil, 2)
+
+	printer.BeginTool(app.Event{
+		ToolName:  tools.ToolNameUnix,
+		ToolInput: map[string]any{"command": "ls -la", "final": true},
+	})
+	printer.PrintDelta("a\nb\nc\nd\ne\n")
+
+	assert.Contains(t, output.String(), "a\nb\nc\nd\ne\n")
+	assert.NotContains(t, output.String(), "truncated")
+	assert.False(t, printer.Truncated())
+
+	output.Reset()
+	printer.BeginTool(app.Event{
+		ToolName:  tools.ToolNameUnix,
+		ToolInput: map[string]any{"command": "echo hi"},
+	})
+	printer.PrintDelta("1\n2\n3\n")
+
+	assert.Contains(t, output.String(), "1\n2\n")
+	assert.Contains(t, output.String(), "truncated")
+	assert.True(t, printer.Truncated())
+}
+
+func TestTaskCommandDirectRawOutputNoTruncationForFinal(t *testing.T) {
+	fullOutput := "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\n"
+	output := runTaskCommandWithConfigAndEvents(t, config.NewDefaultConfig(), []string{"--plain", "list", "files"}, func(req app.TaskRequest) []app.Event {
+		return []app.Event{
+			{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running unix...", ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "ls -la", "final": true}},
+			{Type: app.EventOutputDelta, Text: fullOutput, ToolName: tools.ToolNameUnix},
+			{Type: app.EventCompleted, FinalOutput: fullOutput, RawOutput: fullOutput, RawOutputTool: tools.ToolNameUnix, DirectRawOutput: true},
+		}
+	})
+
+	assert.NotContains(t, output, "truncated")
+	assert.Contains(t, output, "line7\nline8\n")
+	assert.Equal(t, 1, strings.Count(output, "line1"), "output should appear exactly once")
+}
+
+func TestTaskCommandDirectRawOutputShowsFullWhenTruncated(t *testing.T) {
+	fullOutput := "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\n"
+	output := runTaskCommandWithConfigAndEvents(t, config.NewDefaultConfig(), []string{"--plain", "list", "files"}, func(req app.TaskRequest) []app.Event {
+		return []app.Event{
+			{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running unix...", ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "ls -la"}},
+			{Type: app.EventOutputDelta, Text: fullOutput, ToolName: tools.ToolNameUnix},
+			{Type: app.EventCompleted, FinalOutput: fullOutput, RawOutput: fullOutput, RawOutputTool: tools.ToolNameUnix, DirectRawOutput: true},
+		}
+	})
+
+	assert.Contains(t, output, "[tool output truncated:")
+	assert.Contains(t, output, "line7\nline8\n")
+}
+
+func TestTaskCommandDirectRawOutputSuppressedWhenNotTruncated(t *testing.T) {
+	shortOutput := "line1\nline2\n"
+	output := runTaskCommandWithConfigAndEvents(t, config.NewDefaultConfig(), []string{"--plain", "list", "files"}, func(req app.TaskRequest) []app.Event {
+		return []app.Event{
+			{Type: app.EventTaskStatus, Status: string(agent.TaskStatusRunningTool), Text: "Running unix...", ToolName: tools.ToolNameUnix, ToolInput: map[string]any{"command": "ls"}},
+			{Type: app.EventOutputDelta, Text: shortOutput, ToolName: tools.ToolNameUnix},
+			{Type: app.EventCompleted, FinalOutput: shortOutput, RawOutput: shortOutput, RawOutputTool: tools.ToolNameUnix, DirectRawOutput: true},
+		}
+	})
+
+	assert.NotContains(t, output, "truncated")
+	assert.Equal(t, 1, strings.Count(output, "line1"), "full output should not be repeated when live output was complete")
+}
+
 func TestTaskLiveOutputPrinterStylesCommandTrace(t *testing.T) {
 	output := &bytes.Buffer{}
 	printer := newTaskLiveOutputPrinter(output, nil, 2)
@@ -421,6 +504,19 @@ func TestTaskLiveOutputPrinterStylesCommandTrace(t *testing.T) {
 	printer.PrintDelta("diff output\n")
 
 	assert.Equal(t, "\x1b[1;36mCommand:\x1b[0m \x1b[1mgit diff --cached\x1b[0m\ndiff output\n", output.String())
+}
+
+func TestTaskLiveOutputPrinterPythonTrace(t *testing.T) {
+	output := &bytes.Buffer{}
+	printer := newTaskLiveOutputPrinter(output, nil, 10)
+
+	printer.BeginTool(app.Event{ToolName: tools.ToolNamePython, ToolInput: map[string]any{"code": "import os\nprint(os.getcwd())"}})
+	printer.PrintDelta("/home/user\n")
+
+	assert.Contains(t, output.String(), "Python:\n")
+	assert.Contains(t, output.String(), "  import os\n")
+	assert.Contains(t, output.String(), "  print(os.getcwd())\n")
+	assert.NotContains(t, output.String(), "Command:")
 }
 
 func TestFormatTaskTrace(t *testing.T) {

--- a/internal/commands/task_live_output.go
+++ b/internal/commands/task_live_output.go
@@ -12,12 +12,19 @@ import (
 
 const taskLiveOutputMaxLineChars = 120
 
+type toolOutputState struct {
+	printed   bool
+	truncated bool
+}
+
 type taskLiveOutputPrinter struct {
 	out                   io.Writer
 	progress              *taskProgressPrinter
 	limiter               *taskLiveOutputLimiter
 	defaultMaxLines       int
 	toolName              string
+	currentTool           string
+	toolStates            map[string]toolOutputState
 	command               string
 	commandPrinted        bool
 	traceStyling          bool
@@ -34,12 +41,16 @@ func newTaskLiveOutputPrinter(out io.Writer, progress *taskProgressPrinter, maxL
 		progress:              progress,
 		limiter:               newTaskLiveOutputLimiter(maxLines, taskLiveOutputMaxLineChars),
 		defaultMaxLines:       maxLines,
+		toolStates:            make(map[string]toolOutputState),
 		traceStyling:          isTerminalWriter(out),
 		lastChunkEndedNewline: true,
 	}
 }
 
 func (p *taskLiveOutputPrinter) BeginTool(event app.Event) {
+	p.snapshotCurrentTool()
+	p.currentTool = event.ToolName
+
 	isFinal, _ := event.ToolInput["final"].(bool)
 	if isFinal {
 		p.limiter.ResetWithMaxLines(0)
@@ -67,6 +78,11 @@ func (p *taskLiveOutputPrinter) PrintDelta(text string) {
 		p.commandPrinted = true
 	}
 	p.printed = true
+	if p.currentTool != "" {
+		state := p.toolStates[p.currentTool]
+		state.printed = true
+		p.toolStates[p.currentTool] = state
+	}
 	p.lastChunkEndedNewline = strings.HasSuffix(chunk, "\n")
 	_, _ = fmt.Fprint(p.out, chunk)
 }
@@ -77,6 +93,25 @@ func (p *taskLiveOutputPrinter) Printed() bool {
 
 func (p *taskLiveOutputPrinter) Truncated() bool {
 	return p.limiter.truncated
+}
+
+func (p *taskLiveOutputPrinter) snapshotCurrentTool() {
+	if p.currentTool == "" {
+		return
+	}
+	state := p.toolStates[p.currentTool]
+	state.truncated = state.truncated || p.limiter.truncated
+	p.toolStates[p.currentTool] = state
+}
+
+func (p *taskLiveOutputPrinter) PrintedTool(name string) bool {
+	p.snapshotCurrentTool()
+	return p.toolStates[name].printed
+}
+
+func (p *taskLiveOutputPrinter) TruncatedTool(name string) bool {
+	p.snapshotCurrentTool()
+	return p.toolStates[name].truncated
 }
 
 func (p *taskLiveOutputPrinter) NeedsNewlineBeforeFinal() bool {

--- a/internal/commands/task_live_output.go
+++ b/internal/commands/task_live_output.go
@@ -51,6 +51,10 @@ func (p *taskLiveOutputPrinter) BeginTool(event app.Event) {
 	p.snapshotCurrentTool()
 	p.currentTool = event.ToolName
 
+	state := p.toolStates[p.currentTool]
+	state.printed = false
+	p.toolStates[p.currentTool] = state
+
 	isFinal, _ := event.ToolInput["final"].(bool)
 	if isFinal {
 		p.limiter.ResetWithMaxLines(0)

--- a/internal/commands/task_live_output.go
+++ b/internal/commands/task_live_output.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/laszukdawid/terminal-agent/internal/agent"
 	"github.com/laszukdawid/terminal-agent/internal/app"
+	"github.com/laszukdawid/terminal-agent/internal/tools"
 )
 
 const taskLiveOutputMaxLineChars = 120
@@ -15,6 +16,8 @@ type taskLiveOutputPrinter struct {
 	out                   io.Writer
 	progress              *taskProgressPrinter
 	limiter               *taskLiveOutputLimiter
+	defaultMaxLines       int
+	toolName              string
 	command               string
 	commandPrinted        bool
 	traceStyling          bool
@@ -30,14 +33,20 @@ func newTaskLiveOutputPrinter(out io.Writer, progress *taskProgressPrinter, maxL
 		out:                   out,
 		progress:              progress,
 		limiter:               newTaskLiveOutputLimiter(maxLines, taskLiveOutputMaxLineChars),
+		defaultMaxLines:       maxLines,
 		traceStyling:          isTerminalWriter(out),
 		lastChunkEndedNewline: true,
 	}
 }
 
 func (p *taskLiveOutputPrinter) BeginTool(event app.Event) {
-	p.limiter.Reset()
-	p.command = formatTaskStreamedCommand(event)
+	isFinal, _ := event.ToolInput["final"].(bool)
+	if isFinal {
+		p.limiter.ResetWithMaxLines(0)
+	} else {
+		p.limiter.ResetWithMaxLines(p.defaultMaxLines)
+	}
+	p.toolName, p.command = formatTaskStreamedCommand(event)
 	p.commandPrinted = false
 }
 
@@ -54,7 +63,7 @@ func (p *taskLiveOutputPrinter) PrintDelta(text string) {
 		if p.printed && !p.lastChunkEndedNewline {
 			_, _ = fmt.Fprint(p.out, "\n")
 		}
-		_, _ = fmt.Fprintln(p.out, formatTaskTrace("Command", p.command, p.traceStyling))
+		_, _ = fmt.Fprint(p.out, formatToolCommandTrace(p.toolName, p.command, p.traceStyling))
 		p.commandPrinted = true
 	}
 	p.printed = true
@@ -64,6 +73,10 @@ func (p *taskLiveOutputPrinter) PrintDelta(text string) {
 
 func (p *taskLiveOutputPrinter) Printed() bool {
 	return p.printed
+}
+
+func (p *taskLiveOutputPrinter) Truncated() bool {
+	return p.limiter.truncated
 }
 
 func (p *taskLiveOutputPrinter) NeedsNewlineBeforeFinal() bool {
@@ -90,6 +103,11 @@ func (l *taskLiveOutputLimiter) Reset() {
 	l.sawNewline = false
 	l.truncated = false
 	l.truncationAnnounced = false
+}
+
+func (l *taskLiveOutputLimiter) ResetWithMaxLines(maxLines int) {
+	l.maxLines = maxLines
+	l.Reset()
 }
 
 func (l *taskLiveOutputLimiter) Filter(chunk string) string {
@@ -149,11 +167,33 @@ func formatLiveOutputTruncation(shown int, totalLines int, lineMode bool) string
 	return fmt.Sprintf("[tool output truncated: %d lines shown]\n", shown)
 }
 
-func formatTaskStreamedCommand(event app.Event) string {
+func formatTaskStreamedCommand(event app.Event) (toolName, display string) {
 	action := agent.BuildActionString(event.ToolName, event.ToolInput)
-	_, display := agent.ParseToolAndDisplay(action)
+	toolName, display = agent.ParseToolAndDisplay(action)
 	if display != "" {
-		return display
+		return toolName, display
 	}
-	return action
+	return toolName, action
+}
+
+func formatToolCommandTrace(toolName string, command string, styled bool) string {
+	if toolName == tools.ToolNamePython {
+		return formatPythonTrace(command, styled)
+	}
+	return formatTaskTrace("Command", command, styled) + "\n"
+}
+
+func formatPythonTrace(code string, styled bool) string {
+	var out strings.Builder
+	if styled {
+		fmt.Fprintf(&out, "%sPython:%s\n", taskTraceANSIBoldCyan, taskTraceANSIReset)
+	} else {
+		out.WriteString("Python:\n")
+	}
+	for _, line := range strings.Split(code, "\n") {
+		out.WriteString("  ")
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+	return out.String()
 }

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -27,7 +27,7 @@ func (b *BashExecutor) ExecContext(ctx context.Context, code string) (string, er
 	}
 
 	log.Debugw("Executing Unix command", "command", code)
-	cmd := exec.CommandContext(ctx, "bash", "-c", code)
+	cmd := exec.CommandContext(ctx, "bash", "-o", "pipefail", "-c", code)
 	configureCommandCancellation(cmd)
 
 	// Set working directory if provided

--- a/internal/tools/unix_test.go
+++ b/internal/tools/unix_test.go
@@ -99,6 +99,12 @@ func TestUnixToolDoesNotPrintExecutionInternals(t *testing.T) {
 }
 
 func TestBashExecutor(t *testing.T) {
+	t.Run("pipefail catches early pipeline failures", func(t *testing.T) {
+		executor := &BashExecutor{}
+		_, err := executor.Exec("false | true")
+		assert.Error(t, err, "pipefail should propagate failure from early pipeline stage")
+	})
+
 	t.Run("streams output before command completes", func(t *testing.T) {
 		chunks := make(chan string, 4)
 		executor := &BashExecutor{output: testOutputWriter(func(p []byte) (int, error) {


### PR DESCRIPTION
## Summary

- Enable `pipefail` in bash executor so pipeline failures (e.g. `find -printf` on macOS) are detected instead of masked by downstream commands succeeding
- Show full output for `final=true` tools instead of truncating to 6 lines
- Fall back to showing full output at completion when live output was truncated
- Stop appending raw tool output after `final_answer` responses
- Remove duplicate "Executing:" trace after interactive confirmation approval
- Display Python scripts as indented code blocks (`Python:\n  code`) instead of inline bold

## Test plan

- [x] Existing tests pass
- [x] New tests for truncation bypass on final tools
- [x] New tests for DirectRawOutput with and without truncation
- [x] New test for Python trace formatting
- [x] Manual: `agent task "list all files here"` shows full output
- [ ] Manual: `agent task "find files with LLM prompts"` shows clean final answer without raw tool output appended
- [x] Manual: pipeline failure (e.g. `find -printf` on macOS) triggers agent retry