### PR TITLE
Expand read-only Unix auto-approval

### DIFF
--- a/docs/approval-logic.md
+++ b/docs/approval-logic.md
@@ -62,13 +62,16 @@ Default policy is only a fallback. A matching `deny` rule blocks even a read too
 
 ## Read-Only Unix Auto-Approval
 
-`unix` is generally an execute tool, but some Unix commands are read-only. Terminal Agent uses `mvdan.cc/sh` to parse the shell command and auto-approves only commands that satisfy all of these conditions:
+`unix` is generally an execute tool, but some shell programs are safe enough to run without prompting. Terminal Agent uses `mvdan.cc/sh` to parse the shell command and auto-approves only commands that satisfy all of these conditions:
 
-- The command parses as exactly one shell statement.
-- The statement is a simple command or a pipeline of simple commands.
+- The command parses as a shell program made only of approved statement types.
 - Every command in the pipeline is in the read-only allowlist.
+- Sequential commands joined with `;` or `&&` are each independently approved.
+- `cd <dir>` is allowed only when `<dir>` is static, exists, and resolves inside the task root; later statements are checked from that new directory.
+- Static `for ... in ...; do ...; done` loops are allowed only when the iteration list is static and the body is otherwise approved.
 - Every word is static shell syntax: literals, normal single-quoted strings, or normal double-quoted strings with only static content.
-- There are no redirections, background execution, negation, coprocs, disown markers, shell control operators, command substitutions, process substitutions, parameter expansions, arithmetic expansions, variable assignments, subshells, blocks, loops, conditionals, or function declarations.
+- `echo` may use the active static `for` loop variable, e.g. `for i in 1 2 3; do echo "$i"; done`.
+- There are no redirections, background execution, negation, coprocs, disown markers, unapproved shell control operators, command substitutions, process substitutions, parameter expansions outside the narrow static-loop `echo` case, arithmetic expansions, variable assignments, subshells, blocks, unbounded `while`/`until` loops, conditionals, or function declarations.
 - Command-specific write-capable flags are absent.
 
 Examples that run without prompting by default:
@@ -78,6 +81,9 @@ ls -la
 find . -type f | sort | head -20
 ls -la | grep go | wc -l
 env FOO=bar
+cd docs; find . -type f
+cd docs && pwd && find . -type f
+for i in 1 2 3; do echo "$i"; pwd; done
 ```
 
 Examples that still prompt unless explicitly allowed or auto-approved:
@@ -86,11 +92,13 @@ Examples that still prompt unless explicitly allowed or auto-approved:
 find . -delete
 find . -exec rm {} \;
 ls > out.txt
+cd /tmp; find .
 ls && rm file
 ls; rm file
 cat <(rm file)
 FOO=bar ls
 cat file | tee out.txt
+while pwd; do echo ok; done
 ```
 
 The read-only Unix classifier is intentionally conservative. False negatives are acceptable: if a safe command is not recognized, Terminal Agent asks for confirmation instead of running it automatically.

--- a/docs/commands/task.md
+++ b/docs/commands/task.md
@@ -86,7 +86,7 @@ You will be asked to confirm each execution step, and the agent may also ask fol
 
 Action strings use a function-style format, e.g. `unix("aws login sso")` or `file_edit("README.md", operation="write")`. String values use glob matching against the full value: `*` matches any sequence, `?` matches a single character, and character classes like `[ab]` or `[a-z]` are supported. Escape glob metacharacters with `\` when you want a literal match, for example `unix("ls -d \\*/")`. To constrain keys, use `allowKeys=["region", "profile", "read*"]`, and key values can use the same glob syntax, e.g. `region="us-*"`.
 
-Simple read-only Unix commands and pipelines composed only of read-only commands, such as `ls -la | grep go | wc -l`, run without confirmation by default. Commands with redirection, shell control operators, command substitution, assignments, unknown commands, or write-capable actions such as `find -delete` still require confirmation unless allowed or auto-approved.
+Parser-verified safe Unix command sequences, such as `ls -la | grep go | wc -l` or `cd docs; find . -type f`, run without confirmation by default. Commands with redirection, unsafe shell control operators, command substitution, assignments, unknown commands, unbounded loops, or write-capable actions such as `find -delete` still require confirmation unless allowed or auto-approved.
 
 See [Approval Logic](../approval-logic.md) for the complete confirmation and permission decision flow.
 

--- a/internal/agent/readonly_unix.go
+++ b/internal/agent/readonly_unix.go
@@ -1,12 +1,32 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	"mvdan.cc/sh/v3/syntax"
 )
 
-var readOnlyUnixCommands = map[string]struct{}{
+const (
+	awkLongOptionFile    = "--file"
+	awkOptionAssign      = "-v"
+	awkOptionFile        = "-f"
+	awkOptionFieldSep    = "-F"
+	unixCommandCD        = "cd"
+	unixBracketTestClose = "]"
+	parentRelPath        = ".."
+)
+
+type readOnlyCommandPolicy struct {
+	allowLoopVars bool
+	validateArgs  func([]string) bool
+}
+
+var readOnlyUnixCommands = map[string]readOnlyCommandPolicy{
+	":":         {},
+	"[":         {validateArgs: bracketTestAllowsArgs},
+	"awk":       {validateArgs: awkAllowsArgs},
 	"basename":  {},
 	"cat":       {},
 	"cut":       {},
@@ -15,14 +35,17 @@ var readOnlyUnixCommands = map[string]struct{}{
 	"diff":      {},
 	"dirname":   {},
 	"du":        {},
-	"env":       {},
+	"echo":      {allowLoopVars: true},
+	"env":       {validateArgs: envAllowsArgs},
+	"false":     {validateArgs: noArgsAllowed},
 	"file":      {},
-	"find":      {},
+	"find":      {validateArgs: findAllowsArgs},
 	"grep":      {},
 	"head":      {},
 	"id":        {},
 	"ls":        {},
 	"printenv":  {},
+	"printf":    {},
 	"ps":        {},
 	"pwd":       {},
 	"realpath":  {},
@@ -31,8 +54,10 @@ var readOnlyUnixCommands = map[string]struct{}{
 	"sort":      {},
 	"stat":      {},
 	"tail":      {},
+	"test":      {},
 	"tr":        {},
 	"tree":      {},
+	"true":      {validateArgs: noArgsAllowed},
 	"uname":     {},
 	"uniq":      {},
 	"wc":        {},
@@ -49,7 +74,20 @@ var unsafeFindFlags = map[string]struct{}{
 	"-okdir":   {},
 }
 
-func isReadOnlyUnixCommand(command string) bool {
+var unsafeAwkProgramFragments = []string{
+	"system",
+	"getline",
+	">",
+	"|",
+}
+
+type unixSafetyContext struct {
+	rootDir    string
+	currentDir string
+	loopVars   map[string]struct{}
+}
+
+func isReadOnlyUnixCommandInDirs(command string, dirs TaskDirs) bool {
 	command = strings.TrimSpace(command)
 	if command == "" {
 		return false
@@ -57,80 +95,282 @@ func isReadOnlyUnixCommand(command string) bool {
 
 	parser := syntax.NewParser()
 	file, err := parser.Parse(strings.NewReader(command), "")
-	if err != nil || len(file.Stmts) != 1 {
+	if err != nil || len(file.Stmts) == 0 {
 		return false
 	}
 
-	return isReadOnlyStmt(file.Stmts[0])
+	ctx := unixSafetyContext{rootDir: dirs.RootDir, currentDir: dirs.CurrentDir, loopVars: map[string]struct{}{}}
+	for _, stmt := range file.Stmts {
+		if !isReadOnlyStmt(stmt, &ctx) {
+			return false
+		}
+	}
+	return true
 }
 
-func isReadOnlyStmt(stmt *syntax.Stmt) bool {
+func isReadOnlyStmt(stmt *syntax.Stmt, ctx *unixSafetyContext) bool {
 	if stmt == nil || stmt.Cmd == nil {
 		return false
 	}
 	// Redirections and shell modifiers are deliberately rejected, even for input
-	// redirection, to keep auto-approval limited to plain commands and pipelines.
-	if stmt.Negated || stmt.Background || stmt.Coprocess || stmt.Disown || len(stmt.Redirs) > 0 {
+	// redirection, to keep auto-approval limited to parser-verified safe shell.
+	if !isCleanReadOnlyStmt(stmt) {
 		return false
 	}
 
 	switch cmd := stmt.Cmd.(type) {
 	case *syntax.CallExpr:
-		return isReadOnlyCall(cmd)
+		return isReadOnlyCall(cmd, ctx, true)
+	case *syntax.BinaryCmd:
+		switch cmd.Op {
+		case syntax.Pipe:
+			return isReadOnlyPipelineStmt(cmd.X, ctx) && isReadOnlyPipelineStmt(cmd.Y, ctx)
+		case syntax.AndStmt:
+			return isReadOnlyStmt(cmd.X, ctx) && isReadOnlyStmt(cmd.Y, ctx)
+		default:
+			return false
+		}
+	case *syntax.ForClause:
+		return isReadOnlyForClause(cmd, ctx)
+	default:
+		// Subshells, blocks, conditionals, function declarations, and unbounded
+		// while/until loops stay outside the auto-approval surface until they have
+		// explicit handling.
+		return false
+	}
+}
+
+func isReadOnlyPipelineStmt(stmt *syntax.Stmt, ctx *unixSafetyContext) bool {
+	if stmt == nil || stmt.Cmd == nil {
+		return false
+	}
+	if !isCleanReadOnlyStmt(stmt) {
+		return false
+	}
+
+	switch cmd := stmt.Cmd.(type) {
+	case *syntax.CallExpr:
+		return isReadOnlyCall(cmd, ctx, false)
 	case *syntax.BinaryCmd:
 		if cmd.Op != syntax.Pipe {
 			return false
 		}
-		return isReadOnlyStmt(cmd.X) && isReadOnlyStmt(cmd.Y)
+		return isReadOnlyPipelineStmt(cmd.X, ctx) && isReadOnlyPipelineStmt(cmd.Y, ctx)
 	default:
-		// Subshells, blocks, loops, conditionals, and function declarations stay
-		// outside the auto-approval surface until they have explicit handling.
 		return false
 	}
 }
 
-func isReadOnlyCall(call *syntax.CallExpr) bool {
+func isCleanReadOnlyStmt(stmt *syntax.Stmt) bool {
+	return stmt != nil && !stmt.Negated && !stmt.Background && !stmt.Coprocess && !stmt.Disown && len(stmt.Redirs) == 0
+}
+
+func isReadOnlyCall(call *syntax.CallExpr, ctx *unixSafetyContext, allowDirectoryChange bool) bool {
 	if call == nil || len(call.Assigns) > 0 || len(call.Args) == 0 {
 		return false
 	}
 
-	args := make([]string, 0, len(call.Args))
-	for _, word := range call.Args {
-		if !isStaticShellWord(word) {
-			return false
-		}
-		args = append(args, word.Lit())
+	name, ok := staticShellWordValue(call.Args[0])
+	if !ok {
+		return false
 	}
-
-	name := args[0]
 	if strings.Contains(name, "/") {
 		return false
 	}
-	if _, ok := readOnlyUnixCommands[name]; !ok {
-		return false
+
+	if isDirectoryChangeCommand(name) {
+		args, ok := staticShellWordLits(call.Args)
+		return ok && allowDirectoryChange && applyReadOnlyDirectoryChange(args[1:], ctx)
 	}
 
-	return readOnlyCommandAllowsArgs(name, args[1:])
-}
-
-func readOnlyCommandAllowsArgs(name string, args []string) bool {
-	switch name {
-	case "find":
-		for _, arg := range args {
-			if _, unsafe := unsafeFindFlags[arg]; unsafe {
+	policy, ok := readOnlyUnixCommands[name]
+	if !ok {
+		return false
+	}
+	args := make([]string, 0, len(call.Args))
+	for i, word := range call.Args {
+		if i > 0 && policy.allowLoopVars {
+			if !isStaticOrSafeLoopVarShellWord(word, ctx) {
 				return false
 			}
+			args = append(args, word.Lit())
+			continue
 		}
-	case "env":
-		// env can execute a command when given operands. Variable-only operands
-		// still just alter the environment display for env itself.
-		for _, arg := range args {
-			if !strings.Contains(arg, "=") {
+		if !isStaticShellWord(word) {
+			return false
+		}
+		arg, ok := staticShellWordValue(word)
+		if !ok {
+			return false
+		}
+		args = append(args, arg)
+	}
+
+	return readOnlyCommandAllowsArgs(policy, args[1:])
+}
+
+func isDirectoryChangeCommand(name string) bool {
+	return name == unixCommandCD
+}
+
+func staticShellWordLits(words []*syntax.Word) ([]string, bool) {
+	args := make([]string, 0, len(words))
+	for _, word := range words {
+		arg, ok := staticShellWordValue(word)
+		if !ok {
+			return nil, false
+		}
+		args = append(args, arg)
+	}
+	return args, true
+}
+
+func isReadOnlyForClause(clause *syntax.ForClause, ctx *unixSafetyContext) bool {
+	if clause == nil || clause.Select || clause.Braces {
+		return false
+	}
+	iter, ok := clause.Loop.(*syntax.WordIter)
+	if !ok || iter == nil || iter.Name == nil || !iter.InPos.IsValid() || !isValidShellIdentifier(iter.Name.Value) {
+		return false
+	}
+	for _, item := range iter.Items {
+		if !isStaticShellWord(item) {
+			return false
+		}
+	}
+	previousLoopVars := ctx.loopVars
+	ctx.loopVars = copyLoopVars(previousLoopVars)
+	ctx.loopVars[iter.Name.Value] = struct{}{}
+	defer func() { ctx.loopVars = previousLoopVars }()
+	for range iter.Items {
+		for _, stmt := range clause.Do {
+			if !isReadOnlyStmt(stmt, ctx) {
 				return false
 			}
 		}
 	}
 	return true
+}
+
+func applyReadOnlyDirectoryChange(args []string, ctx *unixSafetyContext) bool {
+	if ctx == nil || len(args) != 1 || strings.TrimSpace(args[0]) == "" {
+		return false
+	}
+	if ctx.rootDir == "" || ctx.currentDir == "" {
+		return false
+	}
+
+	target := args[0]
+	if filepath.IsAbs(target) {
+		target = filepath.Clean(target)
+	} else {
+		target = filepath.Join(ctx.currentDir, target)
+	}
+
+	rootDir, err := filepath.Abs(ctx.rootDir)
+	if err != nil {
+		return false
+	}
+	targetDir, err := filepath.Abs(target)
+	if err != nil {
+		return false
+	}
+	rootDir, err = filepath.EvalSymlinks(rootDir)
+	if err != nil {
+		return false
+	}
+	targetDir, err = filepath.EvalSymlinks(targetDir)
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(targetDir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	rel, err := filepath.Rel(rootDir, targetDir)
+	if err != nil || rel == parentRelPath || strings.HasPrefix(rel, parentRelPath+string(os.PathSeparator)) {
+		return false
+	}
+
+	ctx.currentDir = targetDir
+	return true
+}
+
+func readOnlyCommandAllowsArgs(policy readOnlyCommandPolicy, args []string) bool {
+	if policy.validateArgs == nil {
+		return true
+	}
+	return policy.validateArgs(args)
+}
+
+func findAllowsArgs(args []string) bool {
+	for _, arg := range args {
+		if _, unsafe := unsafeFindFlags[arg]; unsafe {
+			return false
+		}
+	}
+	return true
+}
+
+func envAllowsArgs(args []string) bool {
+	// env can execute a command when given operands. Variable-only operands
+	// still just alter the environment display for env itself.
+	for _, arg := range args {
+		if !strings.Contains(arg, "=") {
+			return false
+		}
+	}
+	return true
+}
+
+func awkAllowsArgs(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == awkOptionFile || strings.HasPrefix(arg, awkOptionFile) || arg == awkLongOptionFile:
+			return false
+		case arg == awkOptionAssign:
+			i++
+			if i >= len(args) || !strings.Contains(args[i], "=") {
+				return false
+			}
+			continue
+		case strings.HasPrefix(arg, awkOptionAssign) && strings.Contains(strings.TrimPrefix(arg, awkOptionAssign), "="):
+			continue
+		case arg == awkOptionFieldSep:
+			i++
+			if i >= len(args) {
+				return false
+			}
+			continue
+		case strings.HasPrefix(arg, awkOptionFieldSep):
+			continue
+		case strings.HasPrefix(arg, "-"):
+			return false
+		}
+		return awkProgramAllowsReadOnly(arg)
+	}
+	return false
+}
+
+func awkProgramAllowsReadOnly(program string) bool {
+	for _, fragment := range unsafeAwkProgramFragments {
+		if strings.Contains(program, fragment) {
+			return false
+		}
+	}
+	return true
+}
+
+func bracketTestAllowsArgs(args []string) bool {
+	return len(args) > 0 && args[len(args)-1] == unixBracketTestClose
+}
+
+func noArgsAllowed(args []string) bool {
+	return len(args) == 0
 }
 
 func isStaticShellWord(word *syntax.Word) bool {
@@ -143,6 +383,45 @@ func isStaticShellWord(word *syntax.Word) bool {
 		}
 	}
 	return true
+}
+
+func staticShellWordValue(word *syntax.Word) (string, bool) {
+	if word == nil || len(word.Parts) == 0 {
+		return "", false
+	}
+	var value strings.Builder
+	for _, part := range word.Parts {
+		partValue, ok := staticShellWordPartValue(part)
+		if !ok {
+			return "", false
+		}
+		value.WriteString(partValue)
+	}
+	return value.String(), true
+}
+
+func staticShellWordPartValue(part syntax.WordPart) (string, bool) {
+	switch p := part.(type) {
+	case *syntax.Lit:
+		return p.Value, true
+	case *syntax.SglQuoted:
+		return p.Value, !p.Dollar
+	case *syntax.DblQuoted:
+		if p.Dollar {
+			return "", false
+		}
+		var value strings.Builder
+		for _, nested := range p.Parts {
+			nestedValue, ok := staticShellWordPartValue(nested)
+			if !ok {
+				return "", false
+			}
+			value.WriteString(nestedValue)
+		}
+		return value.String(), true
+	default:
+		return "", false
+	}
 }
 
 func isStaticShellWordPart(part syntax.WordPart) bool {
@@ -164,4 +443,75 @@ func isStaticShellWordPart(part syntax.WordPart) bool {
 	default:
 		return false
 	}
+}
+
+func isStaticOrSafeLoopVarShellWord(word *syntax.Word, ctx *unixSafetyContext) bool {
+	if word == nil || len(word.Parts) == 0 {
+		return false
+	}
+	for _, part := range word.Parts {
+		if !isStaticOrSafeLoopVarShellWordPart(part, ctx) {
+			return false
+		}
+	}
+	return true
+}
+
+func isStaticOrSafeLoopVarShellWordPart(part syntax.WordPart, ctx *unixSafetyContext) bool {
+	if isStaticShellWordPart(part) {
+		return true
+	}
+	switch p := part.(type) {
+	case *syntax.ParamExp:
+		return isSafeLoopVarParamExp(p, ctx)
+	case *syntax.DblQuoted:
+		if p.Dollar {
+			return false
+		}
+		for _, nested := range p.Parts {
+			if !isStaticOrSafeLoopVarShellWordPart(nested, ctx) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func isSafeLoopVarParamExp(exp *syntax.ParamExp, ctx *unixSafetyContext) bool {
+	if exp == nil || exp.Param == nil || ctx == nil || len(ctx.loopVars) == 0 {
+		return false
+	}
+	if exp.Flags != nil || exp.Excl || exp.Length || exp.Width || exp.IsSet || exp.NestedParam != nil || exp.Index != nil || exp.Slice != nil || exp.Repl != nil || exp.Names != 0 || exp.Exp != nil || len(exp.Modifiers) > 0 {
+		return false
+	}
+	_, ok := ctx.loopVars[exp.Param.Value]
+	return ok
+}
+
+func copyLoopVars(vars map[string]struct{}) map[string]struct{} {
+	copy := make(map[string]struct{}, len(vars)+1)
+	for name := range vars {
+		copy[name] = struct{}{}
+	}
+	return copy
+}
+
+func isValidShellIdentifier(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if i == 0 {
+			if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && r != '_' {
+				return false
+			}
+			continue
+		}
+		if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/agent/readonly_unix.go
+++ b/internal/agent/readonly_unix.go
@@ -13,9 +13,15 @@ const (
 	awkOptionAssign      = "-v"
 	awkOptionFile        = "-f"
 	awkOptionFieldSep    = "-F"
+	sedLongOptionFile    = "--file"
+	sedLongOptionInPlace = "--in-place"
+	sedOptionExpression  = "-e"
+	sedOptionFile        = "-f"
+	sedOptionInPlace     = "-i"
 	unixCommandCD        = "cd"
 	unixBracketTestClose = "]"
 	parentRelPath        = ".."
+	sedSubstituteCommand = 's'
 )
 
 type readOnlyCommandPolicy struct {
@@ -50,6 +56,7 @@ var readOnlyUnixCommands = map[string]readOnlyCommandPolicy{
 	"pwd":       {},
 	"realpath":  {},
 	"rg":        {},
+	"sed":       {validateArgs: sedAllowsArgs},
 	"sha256sum": {},
 	"sort":      {},
 	"stat":      {},
@@ -359,6 +366,112 @@ func awkAllowsArgs(args []string) bool {
 func awkProgramAllowsReadOnly(program string) bool {
 	for _, fragment := range unsafeAwkProgramFragments {
 		if strings.Contains(program, fragment) {
+			return false
+		}
+	}
+	return true
+}
+
+func sedAllowsArgs(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	sawScript := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == sedOptionInPlace || strings.HasPrefix(arg, sedOptionInPlace) || strings.HasPrefix(arg, sedLongOptionInPlace):
+			return false
+		case arg == sedOptionFile || strings.HasPrefix(arg, sedOptionFile) || arg == sedLongOptionFile:
+			return false
+		case arg == sedOptionExpression:
+			i++
+			if i >= len(args) || !sedScriptAllowsReadOnly(args[i]) {
+				return false
+			}
+			sawScript = true
+			continue
+		case isSafeSedOption(arg):
+			continue
+		case strings.HasPrefix(arg, "-"):
+			return false
+		}
+
+		if !sawScript {
+			if !sedScriptAllowsReadOnly(arg) {
+				return false
+			}
+			sawScript = true
+		}
+	}
+	return sawScript
+}
+
+func isSafeSedOption(arg string) bool {
+	if arg == "" || arg[0] != '-' || strings.HasPrefix(arg, "--") {
+		return false
+	}
+	for _, flag := range arg[1:] {
+		switch flag {
+		case 'E', 'r', 'n':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func sedScriptAllowsReadOnly(script string) bool {
+	commands := strings.FieldsFunc(script, func(r rune) bool { return r == ';' || r == '\n' })
+	if len(commands) == 0 {
+		return false
+	}
+	for _, command := range commands {
+		if !sedSubstitutionAllowsReadOnly(strings.TrimSpace(command)) {
+			return false
+		}
+	}
+	return true
+}
+
+func sedSubstitutionAllowsReadOnly(command string) bool {
+	if len(command) < 3 || command[0] != sedSubstituteCommand {
+		return false
+	}
+	delimiter := rune(command[1])
+	if delimiter == '\\' || delimiter == '\n' {
+		return false
+	}
+	delimiters := 0
+	escaped := false
+	for i, r := range command[2:] {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if r == delimiter {
+			delimiters++
+			if delimiters == 2 {
+				return sedSubstitutionFlagsAllowReadOnly(command[i+3:])
+			}
+		}
+	}
+	return false
+}
+
+func sedSubstitutionFlagsAllowReadOnly(flags string) bool {
+	for _, flag := range flags {
+		switch {
+		case flag >= '0' && flag <= '9':
+			continue
+		case flag == 'g' || flag == 'i' || flag == 'I' || flag == 'm' || flag == 'M' || flag == 'p':
+			continue
+		default:
 			return false
 		}
 	}

--- a/internal/agent/readonly_unix_test.go
+++ b/internal/agent/readonly_unix_test.go
@@ -1,8 +1,12 @@
 package agent
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-func TestIsReadOnlyUnixCommand(t *testing.T) {
+func TestIsReadOnlyUnixCommandInDirsWithoutPathContext(t *testing.T) {
 	tests := []struct {
 		name    string
 		command string
@@ -10,14 +14,26 @@ func TestIsReadOnlyUnixCommand(t *testing.T) {
 	}{
 		{name: "ls", command: "ls -la", want: true},
 		{name: "find pipeline", command: "find . -type f | sort | head -20", want: true},
+		{name: "grep pipeline true", command: "grep -RIl --exclude-dir=.git --exclude-dir=vendor --exclude=agent --exclude=agent-gui -e 'package ' /home/dawid/projects/terminal-agent | true", want: true},
 		{name: "grep wc pipeline", command: `ls -la | grep "go$" | wc -l`, want: true},
 		{name: "quoted pipe", command: `grep "a|b" file.txt | wc -l`, want: true},
 		{name: "double quoted arg", command: `ls "my dir"`, want: true},
 		{name: "env display", command: "env", want: true},
 		{name: "env variable display", command: "env FOO=bar", want: true},
+		{name: "echo", command: "echo hello", want: true},
+		{name: "colon no-op", command: ":", want: true},
+		{name: "colon static args", command: ": ignored values", want: true},
+		{name: "false", command: "false", want: true},
+		{name: "printf", command: "printf '%s\\n' hello", want: true},
+		{name: "test", command: "test -d .", want: true},
+		{name: "bracket test", command: "[ -d . ]", want: true},
+		{name: "true", command: "true", want: true},
+		{name: "awk field separator", command: `awk -F/ '{print $1}' file.txt`, want: true},
+		{name: "awk variable", command: `awk -v label=name '{print label, $0}' file.txt`, want: true},
 		{name: "path helpers", command: "basename ./foo/bar | dirname ./foo/bar | realpath .", want: true},
 		{name: "checksum and lookup", command: "sha256sum go.mod | cut -d ' ' -f 1", want: true},
 		{name: "diff which tree", command: "diff go.mod go.mod | which go | tree .", want: true},
+		{name: "semicolon safe commands", command: "pwd; ls", want: true},
 		{name: "find delete", command: "find . -delete", want: false},
 		{name: "find exec", command: `find . -exec rm {} \;`, want: false},
 		{name: "redirection", command: "ls > out.txt", want: false},
@@ -25,19 +41,78 @@ func TestIsReadOnlyUnixCommand(t *testing.T) {
 		{name: "background", command: "ls &", want: false},
 		{name: "and operator", command: "ls && rm file", want: false},
 		{name: "semicolon", command: "ls; rm file", want: false},
+		{name: "or operator", command: "ls || pwd", want: false},
+		{name: "while loop", command: "while pwd; do echo ok; done", want: false},
 		{name: "command substitution", command: "echo $(rm file)", want: false},
 		{name: "process substitution", command: "cat <(rm file)", want: false},
 		{name: "tee writes", command: "cat file | tee out.txt", want: false},
 		{name: "env with command", command: "env rm file", want: false},
+		{name: "false with ignored arg", command: "false ignored", want: false},
+		{name: "bracket test missing close", command: "[ -d .", want: false},
+		{name: "printf command substitution", command: "printf '%s\\n' $(rm file)", want: false},
+		{name: "true with ignored arg", command: "true ignored", want: false},
 		{name: "variable assignment", command: "FOO=bar ls", want: false},
 		{name: "dollar single quoted", command: "ls $'my dir'", want: false},
 		{name: "absolute path", command: "/bin/ls", want: false},
+		{name: "awk system", command: `awk 'BEGIN{system("rm file")}'`, want: false},
+		{name: "awk system with spacing", command: `awk 'BEGIN{system ("rm file")}'`, want: false},
+		{name: "awk output redirection", command: `awk '{print $0 > "out.txt"}'`, want: false},
+		{name: "awk external script", command: `awk -f script.awk input.txt`, want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isReadOnlyUnixCommand(tt.command); got != tt.want {
-				t.Fatalf("isReadOnlyUnixCommand(%q) = %v, want %v", tt.command, got, tt.want)
+			if got := isReadOnlyUnixCommandInDirs(tt.command, TaskDirs{}); got != tt.want {
+				t.Fatalf("isReadOnlyUnixCommandInDirs(%q, empty dirs) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsReadOnlyUnixCommandInDirs(t *testing.T) {
+	rootDir := t.TempDir()
+	assetsDir := filepath.Join(rootDir, "assets")
+	nestedDir := filepath.Join(rootDir, "nested")
+	outsideDir := t.TempDir()
+	linkDir := filepath.Join(rootDir, "outside-link")
+
+	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideDir, linkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{name: "cd root and find", command: "cd " + rootDir + " && find assets -maxdepth 1 -type f -printf '%f'", want: true},
+		{name: "cd root semicolon find", command: "cd " + rootDir + "; find assets -maxdepth 1 -type f -printf '%f'", want: true},
+		{name: "cd rg awk sort pipeline", command: "cd " + rootDir + ` && rg -l -w 'package' . | awk 'BEGIN{FS="/"} {n=split($0,a,"/"); f=a[n]; print length(f) "\t" $0}' | sort -n -k1,1 -k2,2`, want: true},
+		{name: "cd relative directory", command: "cd nested; pwd", want: true},
+		{name: "cd back to root", command: "cd nested; cd ..; pwd", want: true},
+		{name: "cd outside root", command: "cd " + outsideDir + "; find . -type f", want: false},
+		{name: "cd symlink outside root", command: "cd " + linkDir + "; find . -type f", want: false},
+		{name: "cd root then unsafe find", command: "cd " + rootDir + "; find . -delete", want: false},
+		{name: "cd in pipeline", command: "cd " + rootDir + " | pwd", want: false},
+		{name: "static for loop", command: "for i in 1 2 3; do echo \"$i\"; pwd; done", want: true},
+		{name: "for loop without static items", command: "for i; do echo \"$i\"; done", want: false},
+		{name: "for loop repeats directory changes", command: "cd nested; for i in 1 2; do cd ..; done; pwd", want: false},
+		{name: "for loop command substitution item", command: "for i in $(ls); do echo \"$i\"; done", want: false},
+		{name: "for loop unsafe body", command: "for i in 1 2 3; do rm file; done", want: false},
+		{name: "for loop unsafe variable use", command: "for i in 1 2 3; do find \"$i\" -type f; done", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirs := TaskDirs{RootDir: rootDir, CurrentDir: rootDir}
+			if got := isReadOnlyUnixCommandInDirs(tt.command, dirs); got != tt.want {
+				t.Fatalf("isReadOnlyUnixCommandInDirs(%q) = %v, want %v", tt.command, got, tt.want)
 			}
 		})
 	}

--- a/internal/agent/readonly_unix_test.go
+++ b/internal/agent/readonly_unix_test.go
@@ -33,6 +33,9 @@ func TestIsReadOnlyUnixCommandInDirsWithoutPathContext(t *testing.T) {
 		{name: "path helpers", command: "basename ./foo/bar | dirname ./foo/bar | realpath .", want: true},
 		{name: "checksum and lookup", command: "sha256sum go.mod | cut -d ' ' -f 1", want: true},
 		{name: "diff which tree", command: "diff go.mod go.mod | which go | tree .", want: true},
+		{name: "sed substitution", command: `rg -l package . | sed 's#^./##g'`, want: true},
+		{name: "sed extended expression", command: `printf '%s\n' hello | sed -E 's/(h)ello/\1i/'`, want: true},
+		{name: "sed multiple expressions", command: `printf '%s\n' hello | sed -e 's/h/H/' -e 's/o/O/'`, want: true},
 		{name: "semicolon safe commands", command: "pwd; ls", want: true},
 		{name: "find delete", command: "find . -delete", want: false},
 		{name: "find exec", command: `find . -exec rm {} \;`, want: false},
@@ -58,6 +61,11 @@ func TestIsReadOnlyUnixCommandInDirsWithoutPathContext(t *testing.T) {
 		{name: "awk system with spacing", command: `awk 'BEGIN{system ("rm file")}'`, want: false},
 		{name: "awk output redirection", command: `awk '{print $0 > "out.txt"}'`, want: false},
 		{name: "awk external script", command: `awk -f script.awk input.txt`, want: false},
+		{name: "sed in place", command: `sed -i 's/a/b/' file.txt`, want: false},
+		{name: "sed external script", command: `sed -f script.sed file.txt`, want: false},
+		{name: "sed execute flag", command: `sed 's/.*/rm file/e'`, want: false},
+		{name: "sed write flag", command: `sed 's/a/b/w out.txt'`, want: false},
+		{name: "sed non substitution command", command: `sed 'w out.txt' file.txt`, want: false},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -434,7 +434,7 @@ func (r *taskExecutionState) progressReporter(toolName string) func(string) {
 func (r *taskExecutionState) autoAllowsTool(tool tools.Tool, input map[string]any) bool {
 	if tool.Name() == tools.ToolNameUnix {
 		command, _ := input["command"].(string)
-		return isReadOnlyUnixCommand(command)
+		return isReadOnlyUnixCommandInDirs(command, r.state.Dirs)
 	}
 
 	switch permissionCategoryFor(tool) {

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -349,6 +349,29 @@ func TestConfirmToolAutoApproveSkipsPrompt(t *testing.T) {
 	}
 }
 
+func TestConfirmToolAutoAllowsSafeCdSequence(t *testing.T) {
+	rootDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "assets"), 0o755))
+	interaction := &fakeTaskInteraction{decision: TaskConfirmationDecision{Allowed: true}}
+	requester := taskUserConfirmationRequester{interaction: interaction}
+	run := &taskExecutionState{
+		state:         &TaskState{Dirs: TaskDirs{RootDir: rootDir, CurrentDir: rootDir}},
+		confirmations: NewConfirmationManager(nil, nil, requester.RequestUserConfirmation, nil),
+	}
+	response := connector.LlmResponseWithTools{
+		ToolName: tools.ToolNameUnix,
+		ToolInput: map[string]any{
+			"command": "cd " + rootDir + " && find assets -maxdepth 1 -type f -printf '%f'",
+		},
+	}
+
+	allowed, err := run.confirmTool(tools.NewUnixTool(nil), response)
+
+	require.NoError(t, err)
+	assert.True(t, allowed)
+	assert.Empty(t, interaction.confirmations)
+}
+
 func TestFinalizeSummaryUsesRenderedTemplate(t *testing.T) {
 	conn := &summaryCaptureConnector{}
 	sysPrompt := "task system prompt"


### PR DESCRIPTION
## Summary
- expand Unix auto-approval from single read-only commands to parser-verified safe command sequences
- allow safe cd state tracking, pipelines, &&, semicolon sequences, static for loops, and harmless builtins
- add conservative awk support for inline read-only formatting pipelines

## Verification
- go test ./internal/agent
- uvx --with mkdocs-material mkdocs build (strict mode still fails on pre-existing unrelated docs warnings in docs/Readme.md and docs/homebrew-setup.md)