### PR TITLE
fix(gui): expand prompt for wrapped input

### DIFF
--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"image/color"
+	"math"
 	"slices"
 	"strings"
 
@@ -29,6 +30,7 @@ const (
 	statusIndicatorSize  float32 = 18
 	providerStatusWidth  float32 = 28
 	providerStatusHeight float32 = 24
+	inputTextInset       float32 = 24
 )
 
 var spinnerFrames = []string{"|", "/", "-", "\\"}
@@ -639,14 +641,12 @@ func environmentSummaryText(result EnvironmentLoadResult) string {
 }
 
 func (p *popupWindow) resizeInput(value string) {
-	rows := strings.Count(value, "\n") + 1
-	if rows < 1 {
-		rows = 1
-	}
-	if rows > maxInputRows {
-		rows = maxInputRows
-	}
+	rows := promptInputRows(value, p.input.Size().Width)
 	p.input.SetMinRowsVisible(rows)
+	p.input.Refresh()
+	if content := p.window.Content(); content != nil {
+		content.Refresh()
+	}
 	current := p.window.Canvas().Size()
 	height := current.Height
 	if height < minWindowHeight {
@@ -656,6 +656,30 @@ func (p *popupWindow) resizeInput(value string) {
 		height = maxWindowHeight
 	}
 	p.window.Resize(fyne.NewSize(max(current.Width, defaultWindowWidth), height))
+}
+
+func promptInputRows(value string, width float32) int {
+	charWidth := fyne.MeasureText("M", theme.TextSize(), fyne.TextStyle{Monospace: true}).Width
+	cols := int((width - inputTextInset) / charWidth)
+	if cols < 1 {
+		cols = 1
+	}
+
+	rows := 0
+	for _, line := range strings.Split(value, "\n") {
+		lineRows := int(math.Ceil(float64(len([]rune(line))) / float64(cols)))
+		if lineRows < 1 {
+			lineRows = 1
+		}
+		rows += lineRows
+	}
+	if rows < 1 {
+		rows = 1
+	}
+	if rows > maxInputRows {
+		rows = maxInputRows
+	}
+	return rows
 }
 
 func withBackground(content fyne.CanvasObject, fill color.Color) fyne.CanvasObject {

--- a/internal/gui/popup_window_test.go
+++ b/internal/gui/popup_window_test.go
@@ -1,6 +1,35 @@
 package gui
 
-import "testing"
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+)
+
+func TestPromptInputRowsExpandsForNewlinesAndWrappedText(t *testing.T) {
+	charWidth := fyne.MeasureText("M", theme.TextSize(), fyne.TextStyle{Monospace: true}).Width
+	widthForTenColumns := inputTextInset + charWidth*10
+
+	tests := []struct {
+		name  string
+		value string
+		want  int
+	}{
+		{name: "single line", value: "short", want: 1},
+		{name: "explicit newline", value: "one\ntwo", want: 2},
+		{name: "wrapped line", value: "12345678901", want: 2},
+		{name: "capped", value: "one\ntwo\nthree\nfour", want: maxInputRows},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := promptInputRows(tt.value, widthForTenColumns); got != tt.want {
+				t.Fatalf("promptInputRows(%q) = %d, want %d", tt.value, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestUnwrapMarkdownFence(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- expand the GUI prompt field based on soft-wrapped text as well as explicit newlines
- refresh the input and window content after row-count changes so the layout grows immediately
- add regression coverage for newline, wrapped, and capped input rows

## Tests
- go test ./internal/gui