### PR TITLE
fix(gui): segment task transcript output

### DIFF
--- a/internal/gui/actions.go
+++ b/internal/gui/actions.go
@@ -62,6 +62,9 @@ func (g *App) cancel() {
 }
 
 func (g *App) copyOutput() {
+	if !hasCopyableResponse(g.state) {
+		return
+	}
 	text := responseCopyText(g.state)
 	if text != "" {
 		g.fyneApp.Clipboard().SetContent(text)
@@ -72,6 +75,9 @@ func (g *App) copyOutput() {
 // a file chosen by the user. It mirrors the "EXPORT LOG" affordance from the
 // brand: a lightweight terminal-output action rather than a document toolbar.
 func (g *App) exportOutput() {
+	if !hasCopyableResponse(g.state) {
+		return
+	}
 	text := responseCopyText(g.state)
 	if text == "" {
 		return

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -249,7 +249,7 @@ func (g *App) render() {
 	g.popup.modelLabel.SetText("MODEL: " + provider + " / " + model)
 	g.popup.setCwd(displayCwd(g.cfg.GetWorkingDir()))
 
-	showAnswer := g.state.output != "" || g.state.isRunning || g.state.errorText != ""
+	showAnswer := g.state.hasResponseContent() || g.state.isRunning || g.state.errorText != ""
 	if showAnswer {
 		g.popup.responseSection.Show()
 	} else {
@@ -332,12 +332,16 @@ func (g *App) renderResponse() {
 		g.popup.setError(g.state.errorText)
 		return
 	}
+	if g.state.mode == guiModeTask {
+		g.popup.setTranscript(g.state.taskTranscript)
+		return
+	}
 	g.popup.setOutput(g.state.output)
 }
 
 // renderOutput pushes the current response into the view.
 func (g *App) renderOutput() {
-	g.popup.setOutput(g.state.output)
+	g.renderResponse()
 }
 
 // setMode switches the active sidebar tab. Switching is ignored while a request
@@ -453,7 +457,7 @@ func metaText(s *state) string {
 	if s.isRunning {
 		return "running…"
 	}
-	if s.errorText != "" || s.output == "" {
+	if s.errorText != "" || !s.hasResponseContent() {
 		return ""
 	}
 	parts := make([]string, 0, 2)
@@ -498,15 +502,18 @@ func displayCwd(dir string) string {
 }
 
 func hasCopyableResponse(s *state) bool {
-	return s.errorText != "" || s.output != ""
+	if s.isRunning {
+		return false
+	}
+	return s.errorText != "" || s.hasResponseContent()
 }
 
 func responseCopyText(s *state) string {
 	if s.errorText != "" {
 		return s.errorText
 	}
-	if s.output != "" {
-		return s.output
+	if s.hasResponseContent() {
+		return s.responseText()
 	}
 	return s.question
 }

--- a/internal/gui/app_test.go
+++ b/internal/gui/app_test.go
@@ -43,6 +43,11 @@ func TestResponseCopyTextFallsBackToOutputThenQuestion(t *testing.T) {
 		t.Fatalf("responseCopyText(withOutput) = %q, want %q", got, "answer")
 	}
 
+	withTaskTranscript := &state{taskTranscript: []transcriptBlock{{Kind: transcriptBlockProse, Text: "Running unix..."}, {Kind: transcriptBlockFinal, Text: "answer"}}}
+	if got := responseCopyText(withTaskTranscript); got != "Running unix...\n\n---\n\nanswer" {
+		t.Fatalf("responseCopyText(withTaskTranscript) = %q", got)
+	}
+
 	withQuestion := &state{question: "question"}
 	if got := responseCopyText(withQuestion); got != "question" {
 		t.Fatalf("responseCopyText(withQuestion) = %q, want %q", got, "question")
@@ -53,8 +58,14 @@ func TestHasCopyableResponseIncludesErrors(t *testing.T) {
 	if !hasCopyableResponse(&state{errorText: "provider failed"}) {
 		t.Fatal("hasCopyableResponse() should be true for errors")
 	}
+	if hasCopyableResponse(&state{isRunning: true, output: "partial"}) {
+		t.Fatal("hasCopyableResponse() should be false while a response is streaming")
+	}
 	if hasCopyableResponse(&state{question: "question only"}) {
 		t.Fatal("hasCopyableResponse() should be false without output or error")
+	}
+	if !hasCopyableResponse(&state{taskTranscript: []transcriptBlock{{Kind: transcriptBlockFinal, Text: "answer"}}}) {
+		t.Fatal("hasCopyableResponse() should be true for task transcripts")
 	}
 }
 

--- a/internal/gui/livelimit.go
+++ b/internal/gui/livelimit.go
@@ -12,9 +12,8 @@ const liveOutputMaxLineChars = 120
 // liveOutputLimiter bounds live tool output to maxLines lines (0 = unlimited),
 // emitting a one-time truncation marker once the limit is hit. It is a port of
 // the CLI taskLiveOutputLimiter (internal/commands/task_live_output.go) so the
-// GUI and CLI truncate identically. The proper fix (a segmented transcript that
-// renders tool output as monospace text rather than markdown) is tracked in
-// GitHub issue #55.
+// GUI and CLI truncate identically; the segmented transcript consumes the
+// filtered chunks directly as monospace tool-output blocks.
 type liveOutputLimiter struct {
 	maxLines            int
 	maxLineChars        int

--- a/internal/gui/popup_window.go
+++ b/internal/gui/popup_window.go
@@ -89,6 +89,7 @@ type popupWindow struct {
 	responseHeading *canvas.Text
 	responseSection *fyne.Container
 	outputField     *widget.RichText
+	transcriptBody  *fyne.Container
 	outputBody      fyne.CanvasObject
 	errorLabel      *widget.Label
 	errorBody       fyne.CanvasObject
@@ -96,6 +97,7 @@ type popupWindow struct {
 	metaLabel       *canvas.Text
 	lastRendered    string
 	lastError       string
+	transcriptViews []transcriptBlockView
 
 	headerStatus    *widget.Label
 	headerBrain     *canvas.Text
@@ -168,6 +170,15 @@ type settingsDialogOptions struct {
 	ModelForProvider func(provider string) string
 	OnSave           func(provider, model string) error
 	OnClosed         func()
+}
+
+type transcriptBlockView struct {
+	kind     transcriptBlockKind
+	text     string
+	chunks   int
+	root     fyne.CanvasObject
+	richText *widget.RichText
+	textGrid *widget.TextGrid
 }
 
 func newProviderStatusIcon(c fyne.Canvas) *providerStatusIcon {
@@ -359,7 +370,11 @@ func (p *popupWindow) buildOutput() {
 	outputField := widget.NewRichText()
 	outputField.Wrapping = fyne.TextWrapWord
 	p.outputField = outputField
-	p.outputBody = outputField
+
+	transcriptBody := container.NewVBox()
+	transcriptBody.Hide()
+	p.transcriptBody = transcriptBody
+	p.outputBody = container.NewStack(outputField, transcriptBody)
 
 	errorLabel := widget.NewLabel("")
 	errorLabel.Wrapping = fyne.TextWrapBreak
@@ -834,6 +849,8 @@ func (p *popupWindow) setCwd(text string) {
 func (p *popupWindow) setOutput(content string) {
 	p.errorBody.Hide()
 	p.outputBody.Show()
+	p.outputField.Show()
+	p.transcriptBody.Hide()
 	if p.lastRendered == content {
 		return
 	}
@@ -841,6 +858,24 @@ func (p *popupWindow) setOutput(content string) {
 	p.outputField.ParseMarkdown(decorateDollarMarkers(unwrapMarkdownFence(content)))
 	p.outputField.Segments = colorizeDollarMarkers(p.outputField.Segments)
 	p.outputField.Refresh()
+}
+
+func (p *popupWindow) setTranscript(blocks []transcriptBlock) {
+	p.errorBody.Hide()
+	p.outputBody.Show()
+	p.outputField.Hide()
+	p.transcriptBody.Show()
+	p.lastRendered = ""
+	if !p.reuseTranscriptViews(blocks) {
+		p.rebuildTranscriptViews(blocks)
+		return
+	}
+	for i := range blocks {
+		if p.transcriptViews[i].sameContent(blocks[i]) {
+			continue
+		}
+		p.refreshTranscriptView(i, blocks[i])
+	}
 }
 
 func (p *popupWindow) setError(content string) {
@@ -851,6 +886,118 @@ func (p *popupWindow) setError(content string) {
 	}
 	p.lastError = content
 	p.errorLabel.SetText(content)
+}
+
+func (p *popupWindow) reuseTranscriptViews(blocks []transcriptBlock) bool {
+	if len(p.transcriptViews) != len(blocks) {
+		return false
+	}
+	for i := range blocks {
+		if p.transcriptViews[i].kind != blocks[i].Kind {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *popupWindow) rebuildTranscriptViews(blocks []transcriptBlock) {
+	p.transcriptViews = make([]transcriptBlockView, len(blocks))
+	p.transcriptBody.Objects = p.transcriptBody.Objects[:0]
+	for i, block := range blocks {
+		view := newTranscriptBlockView(block, i > 0)
+		p.transcriptViews[i] = view
+		p.transcriptBody.Add(view.root)
+	}
+	p.transcriptBody.Refresh()
+}
+
+func newTranscriptBlockView(block transcriptBlock, showFinalSeparator bool) transcriptBlockView {
+	view := transcriptBlockView{kind: block.Kind, text: block.Text, chunks: len(block.Chunks)}
+	switch block.Kind {
+	case transcriptBlockToolOutput:
+		grid := widget.NewTextGrid()
+		grid.Scroll = fyne.ScrollNone
+		appendTextGridText(grid, block.content())
+		view.textGrid = grid
+		view.root = borderedBox(grid, brandBorder)
+	case transcriptBlockFinal:
+		rt := widget.NewRichText()
+		rt.Wrapping = fyne.TextWrapWord
+		view.richText = rt
+		if showFinalSeparator {
+			view.root = container.NewVBox(brandSeparator(), rt)
+		} else {
+			view.root = rt
+		}
+		setTranscriptRichText(rt, block.Text)
+	default:
+		rt := widget.NewRichText()
+		rt.Wrapping = fyne.TextWrapWord
+		view.richText = rt
+		view.root = rt
+		setTranscriptRichText(rt, block.Text)
+	}
+	return view
+}
+
+func (v transcriptBlockView) sameContent(block transcriptBlock) bool {
+	if v.kind != block.Kind {
+		return false
+	}
+	if block.Kind == transcriptBlockToolOutput {
+		return v.chunks == len(block.Chunks) && v.text == block.Text
+	}
+	return v.text == block.Text
+}
+
+func (p *popupWindow) refreshTranscriptView(index int, block transcriptBlock) {
+	view := &p.transcriptViews[index]
+	if view.textGrid != nil {
+		if view.text == block.Text && len(block.Chunks) >= view.chunks {
+			for _, chunk := range block.Chunks[view.chunks:] {
+				appendTextGridTextNoRefresh(view.textGrid, chunk)
+			}
+			view.textGrid.Refresh()
+		} else {
+			view.textGrid.Rows = nil
+			appendTextGridText(view.textGrid, block.content())
+		}
+		view.text = block.Text
+		view.chunks = len(block.Chunks)
+		return
+	}
+	if view.richText != nil {
+		view.text = block.Text
+		setTranscriptRichText(view.richText, view.text)
+	}
+}
+
+func appendTextGridText(grid *widget.TextGrid, text string) {
+	appendTextGridTextNoRefresh(grid, text)
+	grid.Refresh()
+}
+
+func appendTextGridTextNoRefresh(grid *widget.TextGrid, text string) {
+	if text == "" {
+		return
+	}
+	if len(grid.Rows) == 0 {
+		grid.Rows = []widget.TextGridRow{{}}
+	}
+	for _, r := range text {
+		if r == '\n' {
+			grid.Rows = append(grid.Rows, widget.TextGridRow{})
+			continue
+		}
+		last := len(grid.Rows) - 1
+		grid.Rows[last].Cells = append(grid.Rows[last].Cells, widget.TextGridCell{Rune: r})
+	}
+}
+
+func setTranscriptRichText(rt *widget.RichText, content string) {
+	rt.ParseMarkdown(decorateDollarMarkers(unwrapMarkdownFence(content)))
+	rt.Segments = colorizeDollarMarkers(rt.Segments)
+	rt.Refresh()
 }
 
 // unwrapMarkdownFence strips an outer ```markdown or ```md code fence so

--- a/internal/gui/popup_window_test.go
+++ b/internal/gui/popup_window_test.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
 )
 
 func TestBuildOutputWrapsGeneralResponseText(t *testing.T) {
@@ -20,8 +21,61 @@ func TestBuildOutputWrapsGeneralResponseText(t *testing.T) {
 	if p.outputField.Wrapping != fyne.TextWrapWord {
 		t.Fatalf("outputField.Wrapping = %v, want %v", p.outputField.Wrapping, fyne.TextWrapWord)
 	}
+	if p.transcriptBody == nil {
+		t.Fatal("buildOutput should initialize the transcript container")
+	}
 	if p.errorLabel.Wrapping != fyne.TextWrapBreak {
 		t.Fatalf("errorLabel.Wrapping = %v, want %v", p.errorLabel.Wrapping, fyne.TextWrapBreak)
+	}
+}
+
+func TestSetTranscriptReusesExistingToolOutputWidget(t *testing.T) {
+	p := &popupWindow{}
+	p.buildOutput()
+
+	blocks := []transcriptBlock{
+		{Kind: transcriptBlockProse, Text: "Running unix..."},
+		{Kind: transcriptBlockToolOutput, Chunks: []string{"line1\n"}},
+	}
+	p.setTranscript(blocks)
+
+	if len(p.transcriptViews) != 2 {
+		t.Fatalf("transcript view count = %d, want 2", len(p.transcriptViews))
+	}
+	grid := p.transcriptViews[1].textGrid
+	rich := p.transcriptViews[0].richText
+	if grid == nil || rich == nil {
+		t.Fatal("expected rich text and text grid transcript views")
+	}
+
+	updated := []transcriptBlock{
+		{Kind: transcriptBlockProse, Text: "Running unix..."},
+		{Kind: transcriptBlockToolOutput, Chunks: []string{"line1\n", "line2\n"}},
+	}
+	p.setTranscript(updated)
+
+	if p.transcriptViews[1].textGrid != grid {
+		t.Fatal("tool-output updates should reuse the existing text grid")
+	}
+	if p.transcriptViews[0].richText != rich {
+		t.Fatal("unchanged prose blocks should reuse the existing rich text widget")
+	}
+	if got := p.transcriptViews[1].textGrid.Text(); got != "line1\nline2\n" {
+		t.Fatalf("text grid content = %q, want updated output", got)
+	}
+	if p.transcriptViews[1].chunks != 2 {
+		t.Fatalf("tracked chunk count = %d, want 2", p.transcriptViews[1].chunks)
+	}
+}
+
+func TestAppendTextGridTextNoRefreshPreservesChunkBytes(t *testing.T) {
+	grid := widget.NewTextGrid()
+
+	appendTextGridTextNoRefresh(grid, "line1\n")
+	appendTextGridTextNoRefresh(grid, "line2")
+
+	if got := grid.Text(); got != "line1\nline2" {
+		t.Fatalf("text grid text = %q, want exact appended chunks", got)
 	}
 }
 

--- a/internal/gui/screenshot_test.go
+++ b/internal/gui/screenshot_test.go
@@ -19,10 +19,10 @@ import (
 // Usage: GUI_SCREENSHOTS=<abs-dir> go test ./internal/gui/ -run TestCaptureScreenshots
 // (the `task screenshots:gui` wrapper sets GUI_SCREENSHOTS to an absolute path).
 //
-// Note: the pinned Fyne fork's *software* rasterizer underflows when drawing the
-// brand theme's fenced code blocks (zero-stroke rounded rects), so the captured
-// states deliberately avoid triple-backtick code fences. The fenced live-output
-// styling renders correctly under the real GL renderer.
+// Note: the pinned Fyne fork's *software* rasterizer historically underflowed on
+// some rich-text code-block paths, so the captured states still avoid large live
+// tool-output transcripts even though runtime Task output no longer renders via
+// fenced markdown.
 func TestCaptureScreenshots(t *testing.T) {
 	outDir := os.Getenv("GUI_SCREENSHOTS")
 	if outDir == "" {
@@ -63,7 +63,7 @@ func TestCaptureScreenshots(t *testing.T) {
 
 	completedAt := time.Date(2026, 6, 7, 14, 30, 0, 0, time.UTC)
 
-	// Ask mode with a rendered markdown response (no code fence).
+	// Ask mode with a rendered markdown response.
 	g.setMode(guiModeAsk)
 	g.popup.input.SetText("what is terminal agent?")
 	g.state.input = "what is terminal agent?"
@@ -76,9 +76,7 @@ func TestCaptureScreenshots(t *testing.T) {
 	g.render()
 	capture("gui-ask.png")
 
-	// Task mode transcript: a tool-call status line and a final answer. (Live
-	// tool output is wrapped in a fenced code block at runtime; that styling is
-	// GL-only, so it is omitted from this software-rendered capture.)
+	// Task mode transcript: a tool-call status line and a final answer.
 	g.setMode(guiModeTask)
 	g.popup.input.SetText("how many Go files are in internal/gui?")
 	g.state.input = "how many Go files are in internal/gui?"

--- a/internal/gui/state.go
+++ b/internal/gui/state.go
@@ -17,26 +17,26 @@ const (
 	guiModeTask guiMode = "task"
 )
 
-// taskToolFenceMarker opens and closes the fenced code block that wraps live
-// tool stdout/stderr in the Task transcript, keeping shell output readable in
-// the markdown renderer.
+// taskToolFenceMarker is the copy/export fence marker used when serializing
+// task tool-output blocks back to the legacy markdown transcript shape.
 const taskToolFenceMarker = "```"
 
 type state struct {
-	input        string
-	question     string
-	output       string
-	status       string
-	spinnerFrame int
-	errorText    string
-	isRunning    bool
-	isVisible    bool
-	cancelFunc   context.CancelFunc
-	voiceState   voice.State
-	voiceError   string
-	startTime    time.Time
-	completedAt  time.Time
-	elapsed      time.Duration
+	input          string
+	question       string
+	output         string
+	taskTranscript []transcriptBlock
+	status         string
+	spinnerFrame   int
+	errorText      string
+	isRunning      bool
+	isVisible      bool
+	cancelFunc     context.CancelFunc
+	voiceState     voice.State
+	voiceError     string
+	startTime      time.Time
+	completedAt    time.Time
+	elapsed        time.Duration
 
 	// mode is the selected sidebar tab. It deliberately persists across runs and
 	// is not cleared by resetOutput so the chosen tab stays selected.
@@ -46,8 +46,8 @@ type state struct {
 	// Per-run Task streaming state. taskSawLiveOutput records whether any live
 	// tool output streamed this run; taskLiveOutputTools tracks which tools
 	// streamed so completion can avoid duplicating already-shown raw output.
-	// taskToolOpen/taskToolProcessID track the currently open fenced output
-	// block so consecutive chunks render as one contiguous transcript block.
+	// taskToolOpen/taskToolProcessID track the currently open tool-output block so
+	// consecutive chunks render as one contiguous monospace transcript block.
 	taskSawLiveOutput   bool
 	taskLiveOutputTools map[string]bool
 	// taskLiveOutputTruncatedTools records tools whose live output was capped, so
@@ -56,9 +56,10 @@ type state struct {
 	taskLiveOutputTruncatedTools map[string]bool
 	taskToolOpen                 bool
 	taskToolProcessID            int
+	taskToolBlockIndex           int
 
-	// outputDirty marks that state.output changed and the response panel needs a
-	// (coalesced) re-render; the indicator ticker flushes it.
+	// outputDirty marks that the visible response changed and the response panel
+	// needs a (coalesced) re-render; the indicator ticker flushes it.
 	outputDirty bool
 	// taskCurrentToolFinal is set from the running_tool status: final tools stream
 	// unlimited because their output is the run's answer.
@@ -68,19 +69,22 @@ type state struct {
 }
 
 type modeViewState struct {
-	input        string
-	question     string
-	output       string
-	status       string
-	spinnerFrame int
-	errorText    string
-	completedAt  time.Time
-	elapsed      time.Duration
+	input          string
+	question       string
+	output         string
+	taskTranscript []transcriptBlock
+	status         string
+	spinnerFrame   int
+	errorText      string
+	completedAt    time.Time
+	elapsed        time.Duration
 
-	taskSawLiveOutput   bool
-	taskLiveOutputTools map[string]bool
-	taskToolOpen        bool
-	taskToolProcessID   int
+	taskSawLiveOutput            bool
+	taskLiveOutputTools          map[string]bool
+	taskLiveOutputTruncatedTools map[string]bool
+	taskToolOpen                 bool
+	taskToolProcessID            int
+	taskToolBlockIndex           int
 }
 
 func (s *state) saveModeView() {
@@ -91,19 +95,26 @@ func (s *state) saveModeView() {
 	for tool, seen := range s.taskLiveOutputTools {
 		liveOutputTools[tool] = seen
 	}
+	truncatedTools := map[string]bool{}
+	for tool, seen := range s.taskLiveOutputTruncatedTools {
+		truncatedTools[tool] = seen
+	}
 	s.modeViews[s.mode] = modeViewState{
-		input:               s.input,
-		question:            s.question,
-		output:              s.output,
-		status:              s.status,
-		spinnerFrame:        s.spinnerFrame,
-		errorText:           s.errorText,
-		completedAt:         s.completedAt,
-		elapsed:             s.elapsed,
-		taskSawLiveOutput:   s.taskSawLiveOutput,
-		taskLiveOutputTools: liveOutputTools,
-		taskToolOpen:        s.taskToolOpen,
-		taskToolProcessID:   s.taskToolProcessID,
+		input:                        s.input,
+		question:                     s.question,
+		output:                       s.output,
+		taskTranscript:               cloneTranscriptBlocks(s.taskTranscript),
+		status:                       s.status,
+		spinnerFrame:                 s.spinnerFrame,
+		errorText:                    s.errorText,
+		completedAt:                  s.completedAt,
+		elapsed:                      s.elapsed,
+		taskSawLiveOutput:            s.taskSawLiveOutput,
+		taskLiveOutputTools:          liveOutputTools,
+		taskLiveOutputTruncatedTools: truncatedTools,
+		taskToolOpen:                 s.taskToolOpen,
+		taskToolProcessID:            s.taskToolProcessID,
+		taskToolBlockIndex:           s.taskToolBlockIndex,
 	}
 }
 
@@ -116,6 +127,7 @@ func (s *state) restoreModeView(mode guiMode) {
 	s.input = view.input
 	s.question = view.question
 	s.output = view.output
+	s.taskTranscript = cloneTranscriptBlocks(view.taskTranscript)
 	s.status = view.status
 	s.spinnerFrame = view.spinnerFrame
 	s.errorText = view.errorText
@@ -126,13 +138,19 @@ func (s *state) restoreModeView(mode guiMode) {
 	for tool, seen := range view.taskLiveOutputTools {
 		s.taskLiveOutputTools[tool] = seen
 	}
+	s.taskLiveOutputTruncatedTools = map[string]bool{}
+	for tool, seen := range view.taskLiveOutputTruncatedTools {
+		s.taskLiveOutputTruncatedTools[tool] = seen
+	}
 	s.taskToolOpen = view.taskToolOpen
 	s.taskToolProcessID = view.taskToolProcessID
+	s.taskToolBlockIndex = view.taskToolBlockIndex
 }
 
 func (s *state) resetOutput() {
 	s.question = ""
 	s.output = ""
+	s.taskTranscript = nil
 	s.status = ""
 	s.spinnerFrame = 0
 	s.errorText = ""
@@ -150,24 +168,25 @@ func (s *state) resetTaskStreaming() {
 	s.taskLiveOutputTruncatedTools = map[string]bool{}
 	s.taskToolOpen = false
 	s.taskToolProcessID = 0
+	s.taskToolBlockIndex = -1
 	s.outputDirty = false
 	s.taskCurrentToolFinal = false
 	s.taskLiveLimiter = nil
 }
 
-// openTaskToolBlock ensures a fenced output block is open for processID, bounding
+// openTaskToolBlock ensures a tool-output block is open for processID, bounding
 // it to maxLines lines (0 = unlimited). A new process (or no open block) closes
-// any previous fence and opens a fresh one with a fresh limiter so each tool's
+// any previous block and opens a fresh one with a fresh limiter so each tool's
 // live output is its own readable, bounded block.
 func (s *state) openTaskToolBlock(processID, maxLines int) {
 	if s.taskToolOpen && s.taskToolProcessID == processID {
 		return
 	}
 	s.closeTaskToolBlock()
-	s.ensureTrailingNewline()
-	s.output += taskToolFenceMarker + "\n"
+	s.taskTranscript = append(s.taskTranscript, transcriptBlock{Kind: transcriptBlockToolOutput})
 	s.taskToolOpen = true
 	s.taskToolProcessID = processID
+	s.taskToolBlockIndex = len(s.taskTranscript) - 1
 	s.taskLiveLimiter = newLiveOutputLimiter(maxLines, liveOutputMaxLineChars)
 }
 
@@ -178,21 +197,24 @@ func (s *state) appendTaskOutput(text string) {
 	if s.taskLiveLimiter != nil {
 		text = s.taskLiveLimiter.Filter(text)
 	}
-	s.output += text
+	if text == "" || s.taskToolBlockIndex < 0 || s.taskToolBlockIndex >= len(s.taskTranscript) {
+		return
+	}
+	s.taskTranscript[s.taskToolBlockIndex].Chunks = append(s.taskTranscript[s.taskToolBlockIndex].Chunks, text)
 }
 
-// closeTaskToolBlock closes an open fenced output block, if any.
+// closeTaskToolBlock closes an open tool-output block, if any.
 func (s *state) closeTaskToolBlock() {
 	if !s.taskToolOpen {
 		return
 	}
-	s.ensureTrailingNewline()
-	s.output += taskToolFenceMarker + "\n"
 	s.taskToolOpen = false
 	s.taskToolProcessID = 0
+	s.taskToolBlockIndex = -1
+	s.taskLiveLimiter = nil
 }
 
-// appendTaskTranscriptLine closes any open tool-output fence and appends a
+// appendTaskTranscriptLine closes any open tool-output block and appends a
 // non-output transcript line (status/progress) on its own line.
 func (s *state) appendTaskTranscriptLine(line string) {
 	line = strings.TrimSpace(line)
@@ -200,8 +222,7 @@ func (s *state) appendTaskTranscriptLine(line string) {
 		return
 	}
 	s.closeTaskToolBlock()
-	s.ensureTrailingNewline()
-	s.output += line + "\n"
+	s.taskTranscript = append(s.taskTranscript, transcriptBlock{Kind: transcriptBlockProse, Text: line})
 }
 
 // appendTaskFinalText appends final/raw completion text, separating it from any
@@ -210,19 +231,27 @@ func (s *state) appendTaskFinalText(text string) {
 	if text == "" {
 		return
 	}
-	if s.output != "" {
-		s.ensureTrailingNewline()
-		s.output += "\n---\n\n"
-	}
-	s.output += text
+	s.closeTaskToolBlock()
+	s.taskTranscript = append(s.taskTranscript, transcriptBlock{Kind: transcriptBlockFinal, Text: text})
 }
 
-// ensureTrailingNewline normalizes the transcript so the next appended block
-// starts on a fresh line.
-func (s *state) ensureTrailingNewline() {
-	if s.output != "" && !strings.HasSuffix(s.output, "\n") {
-		s.output += "\n"
+func (s *state) appendTaskRawOutput(text string) {
+	if text == "" {
+		return
 	}
+	s.closeTaskToolBlock()
+	s.taskTranscript = append(s.taskTranscript, transcriptBlock{Kind: transcriptBlockToolOutput, Chunks: []string{text}})
+}
+
+func (s *state) hasResponseContent() bool {
+	return s.output != "" || len(s.taskTranscript) > 0
+}
+
+func (s *state) responseText() string {
+	if len(s.taskTranscript) > 0 {
+		return serializeTranscript(s.taskTranscript)
+	}
+	return s.output
 }
 
 func (s *state) setRunning(cancel context.CancelFunc) {

--- a/internal/gui/task.go
+++ b/internal/gui/task.go
@@ -32,9 +32,9 @@ func (g *App) submitTask(ctx context.Context, message string) {
 	go g.consumeTaskEvents(events)
 }
 
-// consumeTaskEvents drains the Task event stream, building a rich transcript in
-// state.output (status/tool-call lines, progress lines, live tool output, and
-// the final answer) while keeping the existing brain/spinner indicators working
+// consumeTaskEvents drains the Task event stream, building a segmented
+// transcript (status/tool-call lines, progress lines, live tool output, and the
+// final answer) while keeping the existing brain/spinner indicators working
 // through the shared status surface.
 func (g *App) consumeTaskEvents(events <-chan appservice.Event) {
 	for event := range events {
@@ -67,9 +67,7 @@ func (g *App) consumeTaskEvents(events <-chan appservice.Event) {
 				}
 				// final/direct-output tools stream unlimited because their output is
 				// the run's answer (matching the CLI). Non-final live output is capped
-				// to GetTaskLiveOutputLimit lines. Large final output is bounded only
-				// by render throttling here; the proper fix is the monospace segmented
-				// transcript tracked in issue #55.
+				// to GetTaskLiveOutputLimit lines.
 				maxLines := 0
 				if !g.state.taskCurrentToolFinal {
 					maxLines = g.cfg.GetTaskLiveOutputLimit()
@@ -103,7 +101,7 @@ func (g *App) consumeTaskEvents(events <-chan appservice.Event) {
 			case appservice.EventCompleted:
 				g.state.closeTaskToolBlock()
 				if shouldAppendTaskFinalOutput(eventCopy, g.state) {
-					g.state.appendTaskFinalText(taskFinalOutputText(eventCopy))
+					g.state.appendTaskCompletionOutput(eventCopy)
 				}
 				g.state.outputDirty = true
 				g.finishRun(nil)
@@ -136,14 +134,14 @@ func shouldAppendTaskFinalOutput(event appservice.Event, s *state) bool {
 	return event.RawOutput != "" && (!s.taskSawLiveOutput || truncated)
 }
 
-// taskFinalOutputText returns the completion text to append: the final answer
-// when present, otherwise the raw output as a fallback. Callers should gate on
-// shouldAppendTaskFinalOutput first.
-func taskFinalOutputText(event appservice.Event) string {
+// appendTaskCompletionOutput appends final prose as markdown and raw fallback as
+// monospace tool output. Callers should gate on shouldAppendTaskFinalOutput first.
+func (s *state) appendTaskCompletionOutput(event appservice.Event) {
 	if event.FinalOutput != "" {
-		return event.FinalOutput
+		s.appendTaskFinalText(event.FinalOutput)
+		return
 	}
-	return event.RawOutput
+	s.appendTaskRawOutput(event.RawOutput)
 }
 
 // isMeaningfulTaskStatus reports whether a task status phase warrants its own
@@ -177,4 +175,3 @@ func formatTaskToolProgress(event appservice.Event) string {
 	}
 	return event.ToolName + ": " + event.Text
 }
-

--- a/internal/gui/task_test.go
+++ b/internal/gui/task_test.go
@@ -128,29 +128,29 @@ func TestSetModeRestoresModeSpecificInputOutputAndExport(t *testing.T) {
 	g.render()
 
 	g.setMode(guiModeTask)
-	if g.state.input != "" || g.state.question != "" || g.state.output != "" {
-		t.Fatalf("new Task view should be empty: input=%q question=%q output=%q", g.state.input, g.state.question, g.state.output)
+	if g.state.input != "" || g.state.question != "" || g.state.responseText() != "" {
+		t.Fatalf("new Task view should be empty: input=%q question=%q output=%q", g.state.input, g.state.question, g.state.responseText())
 	}
 
 	g.state.input = "task input"
 	g.state.question = "task question"
-	g.state.output = "task response"
+	g.state.appendTaskFinalText("task response")
 	g.state.completedAt = completedAtForTest()
 	g.render()
 
 	g.setMode(guiModeAsk)
-	if g.state.input != "ask input" || g.state.question != "ask question" || g.state.output != "ask response" {
-		t.Fatalf("Ask view was not restored: input=%q question=%q output=%q", g.state.input, g.state.question, g.state.output)
+	if g.state.input != "ask input" || g.state.question != "ask question" || g.state.responseText() != "ask response" {
+		t.Fatalf("Ask view was not restored: input=%q question=%q output=%q", g.state.input, g.state.question, g.state.responseText())
 	}
-	if got := g.exportContent(g.state.output); !strings.Contains(got, "# Ask\n\nask question") {
+	if got := g.exportContent(g.state.responseText()); !strings.Contains(got, "# Ask\n\nask question") {
 		t.Fatalf("Ask export used wrong mode/question:\n%s", got)
 	}
 
 	g.setMode(guiModeTask)
-	if g.state.input != "task input" || g.state.question != "task question" || g.state.output != "task response" {
-		t.Fatalf("Task view was not restored: input=%q question=%q output=%q", g.state.input, g.state.question, g.state.output)
+	if g.state.input != "task input" || g.state.question != "task question" || g.state.responseText() != "task response" {
+		t.Fatalf("Task view was not restored: input=%q question=%q output=%q", g.state.input, g.state.question, g.state.responseText())
 	}
-	if got := g.exportContent(g.state.output); !strings.Contains(got, "# Task\n\ntask question") {
+	if got := g.exportContent(g.state.responseText()); !strings.Contains(got, "# Task\n\ntask question") {
 		t.Fatalf("Task export used wrong mode/question:\n%s", got)
 	}
 }
@@ -394,7 +394,7 @@ func TestShouldAppendTaskFinalOutput(t *testing.T) {
 	}
 }
 
-func TestTaskTranscriptStreamingBuildsFencedBlocks(t *testing.T) {
+func TestTaskTranscriptStreamingSerializesToCurrentMarkdownShape(t *testing.T) {
 	s := &state{}
 	s.resetTaskStreaming()
 
@@ -409,7 +409,7 @@ func TestTaskTranscriptStreamingBuildsFencedBlocks(t *testing.T) {
 	s.closeTaskToolBlock()
 	s.appendTaskFinalText("All done.")
 
-	got := s.output
+	got := s.responseText()
 	if strings.Count(got, taskToolFenceMarker) != 2 {
 		t.Fatalf("expected exactly one fenced block (2 markers), got:\n%s", got)
 	}
@@ -429,14 +429,15 @@ func TestAppendTaskOutputRespectsLineCap(t *testing.T) {
 	s.openTaskToolBlock(1, 2) // cap at 2 lines
 	s.appendTaskOutput("one\ntwo\nthree\nfour\n")
 
-	if !strings.Contains(s.output, "one") || !strings.Contains(s.output, "two") {
-		t.Fatalf("first two lines should be present:\n%s", s.output)
+	got := s.responseText()
+	if !strings.Contains(got, "one") || !strings.Contains(got, "two") {
+		t.Fatalf("first two lines should be present:\n%s", got)
 	}
-	if strings.Contains(s.output, "three") {
-		t.Fatalf("capped output must drop later lines:\n%s", s.output)
+	if strings.Contains(got, "three") {
+		t.Fatalf("capped output must drop later lines:\n%s", got)
 	}
-	if !strings.Contains(s.output, "truncated") {
-		t.Fatalf("expected truncation marker:\n%s", s.output)
+	if !strings.Contains(got, "truncated") {
+		t.Fatalf("expected truncation marker:\n%s", got)
 	}
 }
 
@@ -446,13 +447,14 @@ func TestAppendTaskOutputUnlimitedForFinal(t *testing.T) {
 	s.openTaskToolBlock(1, 0) // final tool: unlimited
 	s.appendTaskOutput("a\nb\nc\nd\ne\nf\ng\n")
 
+	got := s.responseText()
 	for _, want := range []string{"a", "g"} {
-		if !strings.Contains(s.output, want) {
-			t.Fatalf("unlimited block dropped %q:\n%s", want, s.output)
+		if !strings.Contains(got, want) {
+			t.Fatalf("unlimited block dropped %q:\n%s", want, got)
 		}
 	}
-	if strings.Contains(s.output, "truncated") {
-		t.Fatalf("unlimited block must not truncate:\n%s", s.output)
+	if strings.Contains(got, "truncated") {
+		t.Fatalf("unlimited block must not truncate:\n%s", got)
 	}
 }
 
@@ -469,7 +471,41 @@ func TestResetOutputClearsTaskStreaming(t *testing.T) {
 	if s.taskSawLiveOutput || s.taskToolOpen || s.taskToolProcessID != 0 || len(s.taskLiveOutputTools) != 0 {
 		t.Fatal("resetOutput must clear per-run task streaming state")
 	}
+	if len(s.taskTranscript) != 0 {
+		t.Fatal("resetOutput must clear the task transcript blocks")
+	}
 	if s.mode != guiModeTask {
 		t.Fatal("resetOutput must not reset the selected mode")
+	}
+}
+
+func TestTaskOutputStreamingKeepsTranscriptInBlocks(t *testing.T) {
+	s := &state{}
+	s.resetTaskStreaming()
+	s.openTaskToolBlock(1, 0)
+	s.appendTaskOutput("hello\n")
+
+	if s.output != "" {
+		t.Fatalf("task streaming should not flatten into state.output, got %q", s.output)
+	}
+	if len(s.taskTranscript) != 1 || s.taskTranscript[0].Kind != transcriptBlockToolOutput {
+		t.Fatalf("unexpected transcript blocks: %#v", s.taskTranscript)
+	}
+	if len(s.taskTranscript[0].Chunks) != 1 || s.taskTranscript[0].Chunks[0] != "hello\n" {
+		t.Fatalf("tool output should be stored as chunks: %#v", s.taskTranscript[0].Chunks)
+	}
+}
+
+func TestTaskCompletionRawOutputAppendsToolOutputBlock(t *testing.T) {
+	s := &state{}
+	s.resetTaskStreaming()
+
+	s.appendTaskCompletionOutput(appservice.Event{RawOutput: "# not markdown\n"})
+
+	if len(s.taskTranscript) != 1 || s.taskTranscript[0].Kind != transcriptBlockToolOutput {
+		t.Fatalf("raw output should append as tool-output block: %#v", s.taskTranscript)
+	}
+	if got := s.responseText(); got != "```\n# not markdown\n```\n" {
+		t.Fatalf("serialized raw output = %q", got)
 	}
 }

--- a/internal/gui/transcript.go
+++ b/internal/gui/transcript.go
@@ -1,0 +1,130 @@
+package gui
+
+import "strings"
+
+type transcriptBlockKind uint8
+
+const (
+	transcriptBlockProse transcriptBlockKind = iota
+	transcriptBlockToolOutput
+	transcriptBlockFinal
+)
+
+type transcriptBlock struct {
+	Kind   transcriptBlockKind
+	Text   string
+	Chunks []string
+}
+
+func cloneTranscriptBlocks(blocks []transcriptBlock) []transcriptBlock {
+	if len(blocks) == 0 {
+		return nil
+	}
+	cloned := make([]transcriptBlock, len(blocks))
+	for i, block := range blocks {
+		cloned[i] = block
+		if len(block.Chunks) > 0 {
+			cloned[i].Chunks = append([]string(nil), block.Chunks...)
+		}
+	}
+	return cloned
+}
+
+func (b transcriptBlock) content() string {
+	if len(b.Chunks) == 0 {
+		return b.Text
+	}
+	var out strings.Builder
+	for _, chunk := range b.Chunks {
+		out.WriteString(chunk)
+	}
+	return out.String()
+}
+
+func serializeTranscript(blocks []transcriptBlock) string {
+	if len(blocks) == 0 {
+		return ""
+	}
+	serializer := transcriptSerializer{}
+	for _, block := range blocks {
+		switch block.Kind {
+		case transcriptBlockToolOutput:
+			serializer.appendToolOutput(block)
+		case transcriptBlockFinal:
+			serializer.appendFinalBlock(block.Text)
+		default:
+			serializer.appendProseBlock(block.Text)
+		}
+	}
+	return serializer.String()
+}
+
+type transcriptSerializer struct {
+	b           strings.Builder
+	endsNewline bool
+}
+
+func (s *transcriptSerializer) String() string {
+	return s.b.String()
+}
+
+func (s *transcriptSerializer) writeString(text string) {
+	s.b.WriteString(text)
+	s.endsNewline = strings.HasSuffix(text, "\n")
+}
+
+func (s *transcriptSerializer) writeByte(ch byte) {
+	s.b.WriteByte(ch)
+	s.endsNewline = ch == '\n'
+}
+
+func (s *transcriptSerializer) ensureNewline() {
+	if s.b.Len() > 0 && !s.endsNewline {
+		s.writeByte('\n')
+	}
+}
+
+func (s *transcriptSerializer) appendProseBlock(text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	s.ensureNewline()
+	s.writeString(text)
+	s.writeByte('\n')
+}
+
+func (s *transcriptSerializer) appendToolOutput(block transcriptBlock) {
+	if block.Text == "" && len(block.Chunks) == 0 {
+		return
+	}
+	s.ensureNewline()
+	s.writeString(taskToolFenceMarker)
+	s.writeByte('\n')
+	endsWithNewline := false
+	if len(block.Chunks) == 0 {
+		s.writeString(block.Text)
+		endsWithNewline = strings.HasSuffix(block.Text, "\n")
+	} else {
+		for _, chunk := range block.Chunks {
+			s.writeString(chunk)
+			endsWithNewline = strings.HasSuffix(chunk, "\n")
+		}
+	}
+	if !endsWithNewline {
+		s.writeByte('\n')
+	}
+	s.writeString(taskToolFenceMarker)
+	s.writeByte('\n')
+}
+
+func (s *transcriptSerializer) appendFinalBlock(text string) {
+	if text == "" {
+		return
+	}
+	if s.b.Len() > 0 {
+		s.ensureNewline()
+		s.writeString("\n---\n\n")
+	}
+	s.writeString(text)
+}


### PR DESCRIPTION
## Summary
- Replace the GUI Task flat markdown transcript with typed prose/tool-output/final blocks
- Render live and raw tool output with monospace TextGrid blocks instead of markdown parsing
- Preserve copy/export markdown serialization and disable copy/export while streaming

## Tests
- go test ./internal/gui/...
- go test ./internal/...

Fixes #55