### PR TITLE
Add opt-out web search to the ask command

### DIFF
--- a/docs/commands/ask.md
+++ b/docs/commands/ask.md
@@ -25,6 +25,9 @@ agent ask --plain "Explain how pipes work in bash"
 # Stream the response (see output as it's generated)
 agent ask --stream "What are the benefits of using Go for CLI applications?"
 
+# Disable web search for a quicker, offline answer
+agent ask --websearch=false "Explain the CAP theorem"
+
 # Include file context
 agent ask --context README.md "Summarize the setup steps"
 
@@ -47,6 +50,7 @@ agent ask "what happened here" -5
 | `--stream` | `-s` | `false` | Stream the response to the stdout as it's generated |
 | `--plain` | `-k` | `false` | Render the response as plain text (no markdown) |
 | `--memory` | `-M` | `false` | Include memory entries in the system prompt |
+| `--websearch` | `-w` | From config (`true`) | Allow the answer to use web search; pass `--websearch=false` for quicker answers |
 | `--context` | `-c` | `[]` | Include file content as context (repeatable) |
 | `--use-terminal-context` |  | `0` (off) | Include latest N terminal entries as context; N must be 1-5 (requires bash-reader plugin) |
 | `--terminal-context-1` | `-1` | `false` | Shortcut for `--use-terminal-context 1` |
@@ -92,6 +96,26 @@ When using the `--stream` flag, you'll see the output appear gradually as it's g
 ```sh
 agent ask --stream "How does Docker containerization work?"
 ```
+
+## Web Search
+
+By default, `ask` may use the built-in `websearch` tool to pull in up-to-date information from the internet before answering. The model decides whether a given question needs a search; questions it can answer from its own knowledge are answered directly.
+
+Web search activates only when all of the following hold:
+
+- It is enabled (the default; configurable with `web_search` in config or the `--websearch` flag).
+- The `TAVILY_KEY` environment variable is set (the `websearch` tool requires it).
+- The selected provider supports tool calling (the local `llama` provider does not).
+
+When any of these is not met, `ask` answers in a single shot without searching, so there is no error or slowdown if web search is unavailable.
+
+Use `--websearch=false` when you want the quickest possible answer and do not need fresh information:
+
+```sh
+agent ask --websearch=false "What is a mutex?"
+```
+
+To turn web search off for every `ask` by default, set `"web_search": false` in `~/.config/terminal-agent/config.json`.
 
 ## Logging
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,6 +225,21 @@ export YZMA_LIB=$HOME/.local/share/yzma/lib
 
 For persistent CLI configuration, add this to your shell profile (`.bashrc`, `.zshrc`, etc.).
 
+### Web Search
+
+The `ask` command can use the built-in `websearch` tool to fetch up-to-date information before answering. It is enabled by default and relies on the [Tavily](https://tavily.com) API.
+
+| Environment Variable | Description |
+|----------------------|-------------|
+| `TAVILY_KEY` | API key used by the `websearch` tool. Web search is skipped when it is unset. |
+
+To control web search:
+
+- Per run: pass `--websearch=false` to `agent ask` for a quicker answer with no search.
+- Globally: set `"web_search": false` in `~/.config/terminal-agent/config.json` (the key defaults to `true` when omitted).
+
+Web search additionally requires a provider that supports tool calling; the local `llama` provider does not, so `ask` answers without searching there. See [Ask Command](./commands/ask.md#web-search) for details.
+
 ### GUI Environment Loading
 
 Desktop-launched GUI processes usually do not source shell startup files directly. On startup, `agent-gui` resolves supported environment variables in this order:

--- a/internal/agent/ask_tools.go
+++ b/internal/agent/ask_tools.go
@@ -1,0 +1,220 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/laszukdawid/terminal-agent/internal/connector"
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+)
+
+// maxAskWebSearchRounds bounds how many websearch calls a single ask run may
+// make. Web search is a narrow, read-only capability; a few rounds is enough to
+// gather context and answer without turning ask into a full agentic loop.
+const maxAskWebSearchRounds = 3
+
+// AskStep is a single observable step of the ask web-search loop. It lets the
+// caller (e.g. session logging) record tool activity without depending on the
+// task package's TaskStep plumbing, keeping ask decoupled from task internals.
+type AskStep struct {
+	Iteration  int
+	ToolName   string
+	ToolInput  map[string]any
+	ToolResult string
+	Err        error
+}
+
+// AskOptions configures an ask run that may use the websearch tool.
+type AskOptions struct {
+	Query string
+	// UseWebSearch is the user's intent for this run. It is necessary but not
+	// sufficient: the loop also requires the capability to be present.
+	UseWebSearch bool
+	// Stream reports whether the caller wants streamed output.
+	Stream bool
+	// OnStream is the optional sink for streamed output chunks.
+	OnStream func(string) error
+	// OnStep is the optional sink for web-search tool steps.
+	OnStep func(AskStep)
+}
+
+// QuestionWithWebSearch answers a question, optionally using the websearch tool
+// in a bounded, read-only loop.
+//
+// The web-search loop runs only when the user enabled it (opts.UseWebSearch)
+// AND the capability is actually present: the connector supports native tool
+// calling and the websearch tool is available (TAVILY_KEY set). Otherwise it
+// falls back to a plain single-shot answer that streams normally.
+//
+// Tool results are threaded back as text in the user prompt because connectors
+// do not carry tool history through QueryParams.Messages, and QueryWithTool does
+// not honor streaming. The loop therefore runs non-streaming and emits the final
+// answer once when streaming was requested.
+func (a *Agent) QuestionWithWebSearch(ctx context.Context, opts AskOptions) (string, error) {
+	if strings.TrimSpace(opts.Query) == "" {
+		return "", ErrEmptyQuery
+	}
+
+	tool, toolConn, ok := a.webSearchCapability()
+	if !opts.UseWebSearch || !ok {
+		// Either the user disabled web search (fast path) or it is unavailable.
+		return a.queryAskPlain(ctx, *a.systemPromptAsk, opts)
+	}
+
+	sysPrompt := *a.systemPromptAsk + AskWebSearchAddendum
+	searched := make(map[string]struct{})
+	var transcript []string
+
+	for round := 0; round < maxAskWebSearchRounds; round++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
+		userPrompt := buildAskWebSearchPrompt(opts.Query, transcript, true)
+		qParams := connector.QueryParams{
+			UserPrompt: &userPrompt,
+			SysPrompt:  &sysPrompt,
+			MaxTokens:  a.maxTokens,
+			Device:     a.device,
+		}
+
+		resp, err := toolConn.QueryWithTool(ctx, &qParams, map[string]tools.Tool{tool.Name(): tool})
+		if err != nil {
+			return "", err
+		}
+		if !resp.ToolUse || resp.ToolName == "" {
+			// Model produced a direct answer.
+			return a.emitFinalAnswer(strings.TrimSpace(resp.Response), opts)
+		}
+		if resp.ToolName != tool.Name() {
+			// Only websearch is offered on the ask path; never execute another
+			// (possibly hallucinated) tool. Stop and answer from what we have.
+			break
+		}
+
+		query := webSearchQuery(resp.ToolInput)
+		if query == "" {
+			// Malformed/empty query: do not spend an API call on it.
+			break
+		}
+		if _, repeated := searched[query]; repeated {
+			// Model asked for a search it already ran; stop looping and answer.
+			break
+		}
+		searched[query] = struct{}{}
+
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		result, runErr := tool.RunSchema(resp.ToolInput)
+		if opts.OnStep != nil {
+			opts.OnStep(AskStep{
+				Iteration:  round + 1,
+				ToolName:   resp.ToolName,
+				ToolInput:  resp.ToolInput,
+				ToolResult: result,
+				Err:        runErr,
+			})
+		}
+		// A failed search is recorded and the model is allowed to answer anyway,
+		// mirroring how the task loop records failures rather than aborting.
+		transcript = append(transcript, formatAskSearchEntry(query, result, runErr))
+	}
+
+	// Loop closed (direct answer not produced, rounds exhausted, or no further
+	// search to run): make one final answer turn from the gathered context. This
+	// turn has no tools and uses the base ask prompt, so the model answers from
+	// the results rather than being told it can keep searching. It streams when
+	// requested.
+	finalOpts := opts
+	finalOpts.Query = buildAskWebSearchPrompt(opts.Query, transcript, false)
+	return a.queryAskPlain(ctx, *a.systemPromptAsk, finalOpts)
+}
+
+// webSearchCapability returns the websearch tool and a tool-calling connector
+// when web search can actually run on the ask path: the tool is available
+// (TAVILY_KEY set, hence present in a.Tools), it is read-category (ask never
+// prompts for confirmation), and the connector supports native tool calling.
+func (a *Agent) webSearchCapability() (tools.Tool, connector.ToolCallingConnector, bool) {
+	tool, ok := a.Tools[tools.ToolNameWebsearch]
+	if !ok {
+		return nil, nil, false
+	}
+	categorized, ok := tool.(tools.CategorizedTool)
+	if !ok || categorized.PermissionCategory() != tools.PermissionRead {
+		return nil, nil, false
+	}
+	toolConn, ok := a.Connector.(connector.ToolCallingConnector)
+	if !ok || !toolConn.SupportsNativeToolCalling() {
+		return nil, nil, false
+	}
+	return tool, toolConn, true
+}
+
+// queryAskPlain performs a single-shot ask answer, streaming when requested.
+func (a *Agent) queryAskPlain(ctx context.Context, sysPrompt string, opts AskOptions) (string, error) {
+	qParams := connector.QueryParams{
+		UserPrompt: &opts.Query,
+		SysPrompt:  &sysPrompt,
+		Stream:     opts.Stream,
+		MaxTokens:  a.maxTokens,
+		Device:     a.device,
+	}
+	if opts.Stream {
+		qParams.OnStream = opts.OnStream
+	}
+	return a.Connector.Query(ctx, &qParams)
+}
+
+// emitFinalAnswer returns an answer obtained from a non-streaming tool round,
+// pushing it through the stream sink once so streaming callers still render it.
+func (a *Agent) emitFinalAnswer(answer string, opts AskOptions) (string, error) {
+	if opts.Stream && opts.OnStream != nil && answer != "" {
+		if err := opts.OnStream(answer); err != nil {
+			return "", err
+		}
+	}
+	return answer, nil
+}
+
+// webSearchQuery extracts the trimmed query string from a websearch tool input.
+func webSearchQuery(input map[string]any) string {
+	if q, ok := input["query"].(string); ok {
+		return strings.TrimSpace(q)
+	}
+	return ""
+}
+
+// formatAskSearchEntry renders one search attempt for the prompt transcript.
+func formatAskSearchEntry(query, result string, err error) string {
+	if err != nil {
+		return fmt.Sprintf("Search %q failed: %v", query, err)
+	}
+	trimmed := strings.TrimSpace(result)
+	if trimmed == "" {
+		return fmt.Sprintf("Search %q returned no results.", query)
+	}
+	return fmt.Sprintf("Search %q results:\n%s", query, trimmed)
+}
+
+// buildAskWebSearchPrompt folds the gathered search transcript back into the
+// user prompt. On the first round (empty transcript) it is just the question.
+// allowMoreSearches controls whether the model is invited to search again: it
+// is true during the loop and false on the final, tool-less answer turn.
+func buildAskWebSearchPrompt(query string, transcript []string, allowMoreSearches bool) string {
+	if len(transcript) == 0 {
+		return query
+	}
+	var b strings.Builder
+	b.WriteString(query)
+	b.WriteString("\n\n<web_search_results>\n")
+	b.WriteString(strings.Join(transcript, "\n\n"))
+	b.WriteString("\n</web_search_results>\n\n")
+	if allowMoreSearches {
+		b.WriteString("Use the web search results above to answer the question. If they are insufficient, you may search again.")
+	} else {
+		b.WriteString("Answer the question using the web search results above. No further web searches are available.")
+	}
+	return b.String()
+}

--- a/internal/agent/ask_tools_test.go
+++ b/internal/agent/ask_tools_test.go
@@ -1,0 +1,344 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/laszukdawid/terminal-agent/internal/connector"
+	"github.com/laszukdawid/terminal-agent/internal/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeWebSearchTool is a read-category stand-in for the websearch tool. It
+// returns scripted outputs (or an injected error) and records its inputs.
+type fakeWebSearchTool struct {
+	outputs []string
+	err     error
+	calls   int
+	inputs  []map[string]any
+}
+
+func (f *fakeWebSearchTool) Name() string { return tools.ToolNameWebsearch }
+func (f *fakeWebSearchTool) PermissionCategory() tools.PermissionCategory {
+	return tools.PermissionRead
+}
+func (f *fakeWebSearchTool) Description() string         { return "" }
+func (f *fakeWebSearchTool) InputSchema() map[string]any { return map[string]any{} }
+func (f *fakeWebSearchTool) HelpText() string            { return "" }
+func (f *fakeWebSearchTool) Run(*string) (string, error) { return f.RunSchema(nil) }
+func (f *fakeWebSearchTool) RunSchema(input map[string]any) (string, error) {
+	f.inputs = append(f.inputs, input)
+	f.calls++
+	if f.err != nil {
+		return "", f.err
+	}
+	if len(f.outputs) == 0 {
+		return "", nil
+	}
+	idx := f.calls - 1
+	if idx >= len(f.outputs) {
+		idx = len(f.outputs) - 1
+	}
+	return f.outputs[idx], nil
+}
+
+func newWebSearchAgent(conn connector.LLMConnector, tool tools.Tool) *Agent {
+	askPrompt := SystemPromptAsk
+	toolSet := map[string]tools.Tool{}
+	if tool != nil {
+		toolSet[tool.Name()] = tool
+	}
+	return &Agent{
+		Connector:       conn,
+		Tools:           toolSet,
+		systemPromptAsk: &askPrompt,
+		maxTokens:       MaxTokens,
+	}
+}
+
+func toolCall(query string) connector.LlmResponseWithTools {
+	return connector.LlmResponseWithTools{
+		ToolUse:   true,
+		ToolName:  tools.ToolNameWebsearch,
+		ToolInput: map[string]any{"query": query},
+	}
+}
+
+func answer(text string) connector.LlmResponseWithTools {
+	return connector.LlmResponseWithTools{Response: text}
+}
+
+func TestQuestionWithWebSearch(t *testing.T) {
+	t.Run("intent off skips tool loop and answers plainly", func(t *testing.T) {
+		conn := &scriptedToolConnector{queryResponse: "plain answer"}
+		ws := &fakeWebSearchTool{outputs: []string{"unused"}}
+		agent := newWebSearchAgent(conn, ws)
+
+		got, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+			Query:        "what time is it",
+			UseWebSearch: false,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "plain answer", got)
+		assert.Equal(t, 0, conn.queryToolCalls, "tool calling must not be attempted")
+		assert.Equal(t, 1, conn.queryCalls, "plain query is used")
+		assert.Equal(t, 0, ws.calls, "websearch must not run when intent is off")
+	})
+
+	t.Run("connector without native tool calling falls back to plain", func(t *testing.T) {
+		conn := &fallbackTaskConnector{queryResponse: "fallback answer"}
+		ws := &fakeWebSearchTool{outputs: []string{"unused"}}
+		agent := newWebSearchAgent(conn, ws)
+
+		got, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+			Query:        "latest go version",
+			UseWebSearch: true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "fallback answer", got)
+		assert.Equal(t, 0, conn.toolCalls, "QueryWithTool must not be called")
+		assert.Equal(t, 0, ws.calls)
+	})
+
+	t.Run("missing websearch tool falls back to plain", func(t *testing.T) {
+		conn := &scriptedToolConnector{queryResponse: "plain answer"}
+		agent := newWebSearchAgent(conn, nil)
+
+		got, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+			Query:        "latest go version",
+			UseWebSearch: true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "plain answer", got)
+		assert.Equal(t, 0, conn.queryToolCalls)
+	})
+
+	t.Run("single search round then answer", func(t *testing.T) {
+		conn := &scriptedToolConnector{responses: []connector.LlmResponseWithTools{
+			toolCall("go 1.30 release date"),
+			answer("Go 1.30 was released."),
+		}}
+		ws := &fakeWebSearchTool{outputs: []string{"- [Go 1.30](https://go.dev)"}}
+		agent := newWebSearchAgent(conn, ws)
+
+		got, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+			Query:        "when was go 1.30 released",
+			UseWebSearch: true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "Go 1.30 was released.", got)
+		assert.Equal(t, 1, ws.calls)
+		assert.Equal(t, 2, conn.queryToolCalls)
+		assert.Equal(t, 0, conn.queryCalls, "no extra plain query when model answers in-loop")
+		// The second tool turn must carry the search results back to the model.
+		require.Len(t, conn.toolPrompts, 2)
+		assert.Contains(t, conn.toolPrompts[1], "web_search_results")
+		assert.Contains(t, conn.toolPrompts[1], "go.dev")
+	})
+
+	t.Run("search failure is recorded and the model still answers", func(t *testing.T) {
+		conn := &scriptedToolConnector{responses: []connector.LlmResponseWithTools{
+			toolCall("flaky query"),
+			answer("Answer despite failed search."),
+		}}
+		ws := &fakeWebSearchTool{err: errors.New("tavily unavailable")}
+		agent := newWebSearchAgent(conn, ws)
+
+		var steps []AskStep
+		got, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+			Query:        "something",
+			UseWebSearch: true,
+			OnStep:       func(s AskStep) { steps = append(steps, s) },
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "Answer despite failed search.", got)
+		assert.Equal(t, 1, ws.calls)
+		require.Len(t, steps, 1)
+		require.Error(t, steps[0].Err)
+		assert.Contains(t, conn.toolPrompts[1], "failed")
+	})
+
+	t.Run("iteration cap forces a final plain answer", func(t *testing.T) {
+		conn := &scriptedToolConnector{
+			responses: []connector.LlmResponseWithTools{
+				toolCall("q1"),
+				toolCall("q2"),
+				toolCall("q3"),
+			},
+			queryResponse: "final answer after cap",
+		}
+		ws := &fakeWebSearchTool{outputs: []string{"r1", "r2", "r3"}}
+		agent := newWebSearchAgent(conn, ws)
+
+		got, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+			Query:        "deep question",
+			UseWebSearch: true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "final answer after cap", got)
+		assert.Equal(t, maxAskWebSearchRounds, ws.calls)
+		assert.Equal(t, maxAskWebSearchRounds, conn.queryToolCalls)
+		assert.Equal(t, 1, conn.queryCalls, "one final plain query closes out the run")
+	})
+
+	t.Run("repeated identical query stops the loop", func(t *testing.T) {
+		conn := &scriptedToolConnector{
+			responses: []connector.LlmResponseWithTools{
+				toolCall("same query"),
+				toolCall("same query"),
+			},
+			queryResponse: "final answer after repeat",
+		}
+		ws := &fakeWebSearchTool{outputs: []string{"r1"}}
+		agent := newWebSearchAgent(conn, ws)
+
+		got, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+			Query:        "deep question",
+			UseWebSearch: true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "final answer after repeat", got)
+		assert.Equal(t, 1, ws.calls, "the repeated search is not executed again")
+		assert.Equal(t, 2, conn.queryToolCalls)
+		assert.Equal(t, 1, conn.queryCalls)
+	})
+
+	t.Run("streaming emits the final answer once on the tool path", func(t *testing.T) {
+		conn := &scriptedToolConnector{responses: []connector.LlmResponseWithTools{
+			toolCall("q"),
+			answer("streamed answer"),
+		}}
+		ws := &fakeWebSearchTool{outputs: []string{"r"}}
+		agent := newWebSearchAgent(conn, ws)
+
+		var chunks []string
+		got, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+			Query:        "q",
+			UseWebSearch: true,
+			Stream:       true,
+			OnStream:     func(c string) error { chunks = append(chunks, c); return nil },
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "streamed answer", got)
+		assert.Equal(t, []string{"streamed answer"}, chunks)
+	})
+
+	t.Run("non-websearch tool call is never executed", func(t *testing.T) {
+		conn := &scriptedToolConnector{
+			responses: []connector.LlmResponseWithTools{
+				{ToolUse: true, ToolName: "python", ToolInput: map[string]any{"code": "print(1)"}},
+			},
+			queryResponse: "answer without running other tools",
+		}
+		ws := &fakeWebSearchTool{outputs: []string{"unused"}}
+		agent := newWebSearchAgent(conn, ws)
+
+		got, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+			Query:        "do something",
+			UseWebSearch: true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "answer without running other tools", got)
+		assert.Equal(t, 0, ws.calls, "only websearch may run on the ask path")
+		assert.Equal(t, 1, conn.queryCalls, "falls through to a final plain answer")
+	})
+
+	t.Run("empty or whitespace query is not searched", func(t *testing.T) {
+		cases := map[string]map[string]any{
+			"missing query":    {},
+			"whitespace query": {"query": "   "},
+			"non-string query": {"query": 42},
+		}
+		for name, input := range cases {
+			t.Run(name, func(t *testing.T) {
+				conn := &scriptedToolConnector{
+					responses: []connector.LlmResponseWithTools{
+						{ToolUse: true, ToolName: tools.ToolNameWebsearch, ToolInput: input},
+					},
+					queryResponse: "final answer",
+				}
+				ws := &fakeWebSearchTool{outputs: []string{"unused"}}
+				agent := newWebSearchAgent(conn, ws)
+
+				got, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+					Query:        "deep question",
+					UseWebSearch: true,
+				})
+
+				require.NoError(t, err)
+				assert.Equal(t, "final answer", got)
+				assert.Equal(t, 0, ws.calls, "an empty query must not reach the search API")
+			})
+		}
+	})
+
+	t.Run("canceled context stops before searching", func(t *testing.T) {
+		conn := &scriptedToolConnector{responses: []connector.LlmResponseWithTools{toolCall("q")}}
+		ws := &fakeWebSearchTool{outputs: []string{"r"}}
+		agent := newWebSearchAgent(conn, ws)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := agent.QuestionWithWebSearch(ctx, AskOptions{Query: "q", UseWebSearch: true})
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 0, ws.calls)
+	})
+
+	t.Run("stream sink error is propagated", func(t *testing.T) {
+		conn := &scriptedToolConnector{responses: []connector.LlmResponseWithTools{
+			toolCall("q"),
+			answer("streamed answer"),
+		}}
+		ws := &fakeWebSearchTool{outputs: []string{"r"}}
+		agent := newWebSearchAgent(conn, ws)
+
+		streamErr := errors.New("sink closed")
+		_, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{
+			Query:        "q",
+			UseWebSearch: true,
+			Stream:       true,
+			OnStream:     func(string) error { return streamErr },
+		})
+		assert.ErrorIs(t, err, streamErr)
+	})
+
+	t.Run("empty query is rejected", func(t *testing.T) {
+		agent := newWebSearchAgent(&scriptedToolConnector{}, nil)
+		_, err := agent.QuestionWithWebSearch(context.Background(), AskOptions{Query: "  "})
+		assert.ErrorIs(t, err, ErrEmptyQuery)
+	})
+}
+
+func TestBuildAskWebSearchPrompt(t *testing.T) {
+	t.Run("no transcript returns the bare query", func(t *testing.T) {
+		assert.Equal(t, "my question", buildAskWebSearchPrompt("my question", nil, true))
+	})
+
+	t.Run("transcript is wrapped and appended", func(t *testing.T) {
+		got := buildAskWebSearchPrompt("my question", []string{"Search \"x\" results:\n- a"}, true)
+		assert.True(t, strings.HasPrefix(got, "my question"))
+		assert.Contains(t, got, "<web_search_results>")
+		assert.Contains(t, got, "</web_search_results>")
+		assert.Contains(t, got, "- a")
+		assert.Contains(t, got, "you may search again")
+	})
+
+	t.Run("final turn does not invite more searches", func(t *testing.T) {
+		got := buildAskWebSearchPrompt("my question", []string{"Search \"x\" results:\n- a"}, false)
+		assert.Contains(t, got, "No further web searches are available")
+		assert.NotContains(t, got, "you may search again")
+	})
+}

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -196,12 +196,23 @@ func getDarwinVersion() string {
 const SystemPromptAsk = `
 {{header}}
 
-You don't have any access to tools. In case the user asks to do something, e.g. execute a command,
-refer them to other functionalities of yours, e.g. requesting the Task command.
+Answer from your own knowledge. You cannot execute commands or modify files; if the user asks you to
+do something like that, refer them to other functionalities of yours, e.g. requesting the Task command.
 
 Always strive for accuracy, clarity, and efficiency in your responses. You must be consise.
 
 Remember, you are an AI assistant, and your primary goal is to help the user accomplish their tasks effectively and efficiently while maintaining the integrity and security of their development environment.
+`
+
+// AskWebSearchAddendum is appended to the resolved ask prompt only when web
+// search is effectively active (the user has it enabled and the connector plus
+// the websearch tool are actually available). It grants the single websearch
+// capability without implying access to any other tools.
+const AskWebSearchAddendum = `
+You additionally have access to a ` + "`websearch`" + ` tool that searches the web for current information.
+Call it only when the question needs fresh, external, or factual information you are not confident about;
+otherwise answer directly. You have no other tools, so for actions such as executing commands or editing
+files continue to refer the user to the Task command.
 `
 
 const SystemPromptTask = `

--- a/internal/app/ask.go
+++ b/internal/app/ask.go
@@ -7,7 +7,6 @@ import (
 
 	internalagent "github.com/laszukdawid/terminal-agent/internal/agent"
 	"github.com/laszukdawid/terminal-agent/internal/config"
-	"github.com/laszukdawid/terminal-agent/internal/connector"
 	"github.com/laszukdawid/terminal-agent/internal/sessionlog"
 )
 
@@ -22,6 +21,7 @@ type AskRequest struct {
 	ContextFiles         []string
 	TerminalContextCount int
 	Stream               bool
+	UseWebSearch         bool
 	Device               string
 	Config               config.Config
 }
@@ -74,23 +74,41 @@ func (s *service) AskEvents(ctx context.Context, req AskRequest) (<-chan Event, 
 			return
 		}
 
-		qParams := connector.QueryParams{
-			UserPrompt: &userQuestion,
-			SysPrompt:  &prompts.Ask,
-			Stream:     req.Stream,
-			MaxTokens:  req.Config.GetMaxTokens(),
-			Device:     req.Device,
+		opts := internalagent.AskOptions{
+			Query:        userQuestion,
+			UseWebSearch: req.UseWebSearch,
+			Stream:       req.Stream,
+			OnStep: func(step internalagent.AskStep) {
+				recorder.Write(sessionlog.Record{
+					Type:      sessionlog.RecordToolCall,
+					Kind:      string(RunKindAsk),
+					Iteration: step.Iteration,
+					ToolName:  step.ToolName,
+					ToolInput: step.ToolInput,
+				})
+				result := sessionlog.Record{
+					Type:       sessionlog.RecordToolResult,
+					Kind:       string(RunKindAsk),
+					Iteration:  step.Iteration,
+					ToolName:   step.ToolName,
+					ToolResult: step.ToolResult,
+				}
+				if step.Err != nil {
+					result.Error = step.Err.Error()
+				}
+				recorder.Write(result)
+			},
 		}
 
 		if req.Stream {
-			qParams.OnStream = func(chunk string) error {
+			opts.OnStream = func(chunk string) error {
 				event := newEvent(RunKindAsk, EventOutputDelta)
 				event.Text = chunk
 				return emitEvent(ctx, events, event)
 			}
 		}
 
-		response, err := agentInstance.Connector.Query(ctx, &qParams)
+		response, err := agentInstance.QuestionWithWebSearch(ctx, opts)
 		if err != nil {
 			failed := newEvent(RunKindAsk, EventFailed)
 			failed.Err = err

--- a/internal/commands/ask_cmd.go
+++ b/internal/commands/ask_cmd.go
@@ -49,6 +49,7 @@ func NewQuestionCommand(config config.Config) *cobra.Command {
 			streamFlag, _ := flags.GetBool("stream")
 			plainFlag, _ := flags.GetBool("plain")
 			memoryFlag, _ := flags.GetBool("memory")
+			webSearchFlag, _ := flags.GetBool("websearch")
 
 			// Concatenate all remaining args to form the query
 			userQuestion := strings.Join(args, " ")
@@ -68,6 +69,7 @@ func NewQuestionCommand(config config.Config) *cobra.Command {
 				ContextFiles:         contextFiles,
 				TerminalContextCount: terminalContextCount,
 				Stream:               streamFlag,
+				UseWebSearch:         webSearchFlag,
 				Device:               device,
 				Config:               execConfig,
 			})
@@ -122,6 +124,12 @@ func NewQuestionCommand(config config.Config) *cobra.Command {
 
 	// 'memory' flag whether to include memory in the system prompt (default: false)
 	cmd.Flags().BoolP("memory", "M", false, "Include memory in the system prompt")
+
+	// 'websearch' flag whether ask may use the websearch tool. Defaults to the
+	// config value (on unless disabled); use --websearch=false for quicker,
+	// offline answers. Web search additionally requires TAVILY_KEY and a
+	// tool-calling provider, otherwise ask answers without it.
+	cmd.Flags().BoolP("websearch", "w", config.GetWebSearch(), "Allow web search for up-to-date information (use --websearch=false for quicker answers)")
 
 	// 'context' flag to include file contents as context (can be used multiple times)
 	cmd.Flags().StringArrayVarP(&contextFiles, "context", "c", []string{}, "Include file content as context (can be used multiple times)")

--- a/internal/commands/ask_cmd_test.go
+++ b/internal/commands/ask_cmd_test.go
@@ -3,10 +3,40 @@ package commands
 import (
 	"testing"
 
+	"github.com/laszukdawid/terminal-agent/internal/config"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestWebSearchFlag verifies the --websearch flag default is bound to the config
+// value (on by default) and can be explicitly overridden on the command line.
+func TestWebSearchFlag(t *testing.T) {
+	t.Run("defaults to config value when on", func(t *testing.T) {
+		cmd := NewQuestionCommand(config.NewDefaultConfig())
+		val, err := cmd.Flags().GetBool("websearch")
+		require.NoError(t, err)
+		assert.True(t, val, "web search defaults on")
+	})
+
+	t.Run("config disabled flips the default off", func(t *testing.T) {
+		cfg := config.NewDefaultConfig()
+		off := false
+		cfg.WebSearch = &off
+		cmd := NewQuestionCommand(cfg)
+		val, err := cmd.Flags().GetBool("websearch")
+		require.NoError(t, err)
+		assert.False(t, val, "config default carries into the flag default")
+	})
+
+	t.Run("--websearch=false overrides an on default", func(t *testing.T) {
+		cmd := NewQuestionCommand(config.NewDefaultConfig())
+		require.NoError(t, cmd.Flags().Parse([]string{"--websearch=false"}))
+		val, err := cmd.Flags().GetBool("websearch")
+		require.NoError(t, err)
+		assert.False(t, val)
+	})
+}
 
 // TestMemoryFlagBehavior tests the logic that determines when memory should be included
 func TestMemoryFlagBehavior(t *testing.T) {

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -46,6 +46,8 @@ type Config interface {
 	GetTaskLiveOutputLimit() int
 	GetMemory() bool
 	SetMemory(bool) error
+	GetWebSearch() bool
+	SetWebSearch(bool) error
 	GetPermissions() Permissions
 	GetProjectContext() bool
 }
@@ -75,6 +77,7 @@ type config struct {
 	TaskTimeout         string            `json:"task_timeout,omitempty"`
 	TaskLiveOutputLimit *int              `json:"task_live_output_limit,omitempty"`
 	Memory              bool              `json:"memory"`
+	WebSearch           *bool             `json:"web_search,omitempty"`
 	ProjectContext      *bool             `json:"project_context,omitempty"`
 	Permissions         Permissions       `json:"permissions,omitempty"`
 }
@@ -498,6 +501,22 @@ func (config *config) GetMemory() bool {
 func (config *config) SetMemory(enabled bool) error {
 	log.Debugw("Setting memory", "enabled", enabled)
 	config.Memory = enabled
+	return SaveConfig(config)
+}
+
+// GetWebSearch reports whether the ask command may use the websearch tool.
+// It defaults to true when unset so web search is on out of the box; setting
+// web_search to false in config disables it for quicker, offline answers.
+func (config *config) GetWebSearch() bool {
+	if config.WebSearch == nil {
+		return true
+	}
+	return *config.WebSearch
+}
+
+func (config *config) SetWebSearch(enabled bool) error {
+	log.Debugw("Setting web search", "enabled", enabled)
+	config.WebSearch = &enabled
 	return SaveConfig(config)
 }
 

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -349,6 +349,27 @@ func TestGetProjectContext(t *testing.T) {
 	})
 }
 
+func TestGetWebSearch(t *testing.T) {
+	t.Run("defaults to true when nil", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		assert.True(t, cfg.GetWebSearch())
+	})
+
+	t.Run("returns true when explicitly set", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		val := true
+		cfg.WebSearch = &val
+		assert.True(t, cfg.GetWebSearch())
+	})
+
+	t.Run("returns false when explicitly disabled", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		val := false
+		cfg.WebSearch = &val
+		assert.False(t, cfg.GetWebSearch())
+	})
+}
+
 func TestGetTaskTimeout(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/gui/voice_test.go
+++ b/internal/gui/voice_test.go
@@ -257,6 +257,8 @@ func (c voiceGUIConfig) GetTaskTimeout() time.Duration                  { return
 func (c voiceGUIConfig) GetTaskLiveOutputLimit() int                    { return 0 }
 func (c voiceGUIConfig) GetMemory() bool                                { return false }
 func (c voiceGUIConfig) SetMemory(bool) error                           { return nil }
+func (c voiceGUIConfig) GetWebSearch() bool                             { return true }
+func (c voiceGUIConfig) SetWebSearch(bool) error                        { return nil }
 func (c voiceGUIConfig) GetPermissions() config.Permissions             { return config.Permissions{} }
 func (c voiceGUIConfig) GetProjectContext() bool                        { return false }
 

--- a/internal/voice/stt/factory_test.go
+++ b/internal/voice/stt/factory_test.go
@@ -45,5 +45,7 @@ func (c factoryConfig) GetTaskTimeout() time.Duration                  { return 
 func (c factoryConfig) GetTaskLiveOutputLimit() int                    { return 0 }
 func (c factoryConfig) GetMemory() bool                                { return false }
 func (c factoryConfig) SetMemory(bool) error                           { return nil }
+func (c factoryConfig) GetWebSearch() bool                             { return true }
+func (c factoryConfig) SetWebSearch(bool) error                        { return nil }
 func (c factoryConfig) GetPermissions() config.Permissions             { return config.Permissions{} }
 func (c factoryConfig) GetProjectContext() bool                        { return false }


### PR DESCRIPTION
## Summary

Gives the `ask` command an optional web-search capability backed by the existing Tavily `websearch` tool. The model may search the web for up-to-date information before answering; questions it can answer from its own knowledge are answered directly. Web search is on by default and can be turned off for quicker, offline answers.

## How it works

A small, bounded, read-only loop on the ask path drives the `websearch` tool through the connector's `QueryWithTool`:

- Because connectors do not carry tool history through `QueryParams.Messages` (and `connector.Message` cannot encode tool-call structures), search results are threaded back as text in the user prompt, the same approach the task loop uses for its step history.
- Tool rounds run non-streaming (`QueryWithTool` does not honor `OnStream`); the final answer is emitted once through the stream sink when streaming was requested.
- The final answer turn has no tools and uses the base ask prompt, so the model answers from the gathered results rather than being told it can keep searching.

## Toggle: three layers

- **Intent**: new `web_search` config key (`*bool`, defaults to `true`) plus the `--websearch`/`-w` flag, whose default is bound to the config value. Use `--websearch=false` for a quick answer.
- **Capability**: the connector must support native tool calling (the local `llama` provider does not) and the `websearch` tool must be available (`TAVILY_KEY` set).
- **Effective** = intent AND capability. Only then is the websearch addendum added to the ask system prompt. When disabled or unavailable, `ask` answers in a single shot with no error or slowdown.

## Robustness

The loop validates that the requested tool is actually `websearch` (never executes a hallucinated tool), skips empty or malformed queries, guards against repeated identical searches, bounds itself to a few rounds, records failed searches and answers anyway, and honors context cancellation. It stays decoupled from task-only execution paths (its own `AskStep`/`AskOptions`, no task step plumbing).

## Tests

- Agent loop: intent off, no native tool calling, missing tool, single search, search failure, iteration cap, repeated query, streaming emit, non-websearch tool, empty/whitespace/non-string query, canceled context, stream-sink error, empty query.
- Config: `GetWebSearch` default-true and override.
- CLI: `--websearch` default bound to config and `--websearch=false` override.

## Docs

Updated `docs/commands/ask.md` (flag + Web Search section) and `docs/configuration.md` (`TAVILY_KEY` + `web_search`).